### PR TITLE
Add changes to explain chain upgrades and syncing process

### DIFF
--- a/docs/evm-sidechain/install-cosmovisor.md
+++ b/docs/evm-sidechain/install-cosmovisor.md
@@ -1,0 +1,111 @@
+---
+html: install-cosmovisor.html
+parent: evm-sidechains.html
+blurb: Install cosmovisor for automated upgrades
+labels:
+  - Development, Interoperability
+status: not_enabled
+
+---
+
+# Install Cosmovisor
+
+[Cosmovisor](https://docs.cosmos.network/main/build/tooling/cosmovisor) is a small process manager for Cosmos SDK application binaries that monitors the governance module for incoming chain upgrade proposals. If it sees a proposal that gets approved, cosmovisor can automatically download the new binary, stop the current binary, switch from the old binary to the new one, and finally restart the node with the new binary.
+
+The following section gives details on how to perform a migration to cosmovisor using docker.
+
+## Backup node data
+
+After performing any important maintenance action such as this one, you should first back up all the node files such as the private keys and the blockchain history. All this data can be found in the folder  `.exrpd` in the root of the node. If you followed the docker installation guide, the folder should be under `~/.exrpd` .
+
+**⚠️ Before continuing, please make sure you have a copy of this entire folder. The most important files are `~/.exrpd/config` and `~/.exrpd/keyring*` .**
+
+## Remove the node container
+
+The first thing we have to do is to stop the docker container running the node. We can list what running containers are in the machine by running `docker ps`
+
+```bash
+validator-node:~# docker ps
+CONTAINER ID   IMAGE                                COMMAND                  CREATED       STATUS       PORTS                                           NAMES
+a2a5c4d97b5b   peersyst/exrp-cosmovisor:latest      "sh -c …"                13 days ago   Up 13 days   0.0.0.0:26656->26656/tcp, :::26656->26656/tcp   validator
+```
+
+After seeing the listing containers, we can then stop and remove the container by running `docker kill <container_name>` and `docker rm <container_name>`
+
+```bash
+validator-node:~# docker kill validator
+validator-node:~# docker rm validator
+```
+
+## Initialize the Cosmovisor client
+
+The very first step is to pull the latest cosmovisor image from the docker registry by running `docker pull peersyst/exrp-cosmovisor:latest`
+
+```bash
+validator-node:~# docker pull peersyst/exrp-cosmovisor:latest
+latest: Pulling from peersyst/exrp-cosmovisor
+f56be85fc22e: Already exists 
+78134ebb758f: Pull complete 
+6e29bafc19de: Pull complete 
+ce839fca64c6: Pull complete 
+5e741889d497: Pull complete 
+182ead5dc398: Pull complete 
+60e70e19a85a: Pull complete 
+Digest: sha256:fea74e4253b1d4cca78ea15b599a3736cfe99980a78663294ab48603d64dda16
+Status: Downloaded newer image for peersyst/exrp-cosmovisor:latest
+docker.io/peersyst/exrp-cosmovisor:latest
+```
+
+After pulling the docker image, we can initialize the new version by running `docker run --rm -v $HOME/.exrpd:/root/.exrpd peersyst/exrp-cosmovisor:latest initialize`
+
+```bash
+validator-node:~# docker run -it --rm -v $HOME/.exrpd:/root/.exrpd peersyst/exrp-cosmovisor:latest initialize
+```
+
+After running this command we should see the **cosmovisor** folder created in our node home:
+```bash
+validator-node:~# ls -la $HOME/.exrpd
+total 32
+drwxr-xr-x 8 root root 4096 May 22 07:48 .
+drwx------ 6 root root 4096 May  9 15:11 ..
+drwxr-xr-x 3 root root 4096 May 22 07:46 config
+drwxr-xr-x 3 root root 4096 May 22 07:48 cosmovisor
+drwx------ 9 root root 4096 May 22 07:47 data
+drwx------ 2 root root 4096 Jun  2  2023 keyring-file
+
+validator-node-0:~# ls -la $HOME/.exrpd/cosmovisor/
+total 12
+drwxr-xr-x 3 root root 4096 May 22 07:50 .
+drwxr-xr-x 8 root root 4096 May 22 07:48 ..
+lrwxrwxrwx 1 root root   31 May 22 07:50 current -> /root/.exrpd/cosmovisor/genesis
+drwxr-xr-x 3 root root 4096 May 22 07:48 genesis
+```
+
+## Start the cosmovisor client
+
+The next step after initializing, is to start the cosmovisor client. To do so, we are going to create a new docker container that will use the cosmovisor image by running `docker run -d -p 26656:26656 -v <node_home>:/root/.exrpd peersyst/exrp-cosmovisor:latest cosmovisor run start`
+
+```bash
+validator-node:~# docker run -d --name validator -p 26656:26656 -v $HOME/.exrpd:/root/.exrpd peersyst/exrp-cosmovisor:latest cosmovisor run start
+```
+
+After we run this command, we can check that the container is running with the `docker ps`  command.
+
+```bash
+validator-node:~# docker ps
+CONTAINER ID   IMAGE                                COMMAND                  CREATED          STATUS          PORTS                                           NAMES
+a2a5c4d97b5b   peersyst/exrp-cosmovisor:latest      "cosmovisor run start"   10 seconds ago   Up 10 seconds   0.0.0.0:26656->26656/tcp, :::26656->26656/tcp   validator
+```
+
+And check the logs of the container by running `docker logs --tail 100 -f <container_name>`. After some time we should see usual activity in our node being in sync with the network.
+
+```bash
+validator-node:~# docker logs --tail=100 -f validator
+6:00PM INF commit synced commit=436F6D6D697449447B5B37392032343020313133203133382035342031373020393320313637203135392031353120313436203136302032313320343720313033203533203130382039372036203737203536203130382039203130322032313120382031333320323033203235302031343320313636203134375D3A3739313234427D
+6:00PM INF committed state app_hash=4FF0718A36AA5DA79F9792A0D52F67356C61064D386C0966D30885CBFA8FA693 height=7934539 module=state num_txs=0 server=node
+6:00PM INF indexed block exents height=7934539 module=txindex server=node
+6:00PM INF Timed out dur=2976.595543 height=7934540 module=consensus round=0 server=node step=1
+6:00PM INF received proposal module=consensus proposal={"Type":32,"block_id":{"hash":"1B25046566DDE8C009321B627AB1C0C8CC162CE07D5E77BD5725F8C8FA45FC6F","parts":{"hash":"8BE3F8E82916DBA87A3A63B6C8405FC478440658CA5979EEC8E0574888BE67F0","total":1}},"height":7934540,"pol_round":-1,"round":0,"signature":"l1PaiPtgG8qZxWgHrdyfnXOnWmnKI4fVSPeWQLRvRG/ryumf+N3+M8f5VBDAydJfaE0cOVyiCeBejjDoAw8hDw==","timestamp":"2024-04-23T18:00:34.988182155Z"} server=node
+6:00PM INF received complete proposal block hash=1B25046566DDE8C009321B627AB1C0C8CC162CE07D5E77BD5725F8C8FA45FC6F height=7934540 module=consensus server=node
+6:00PM INF finalizing commit of block hash={} height=7934540 module=consensus num_txs=0 root=4FF0718A36AA5DA79F9792A0D52F67356C61064D386C0966D30885CBFA8FA693 server=node
+```

--- a/docs/evm-sidechain/introduction-to-chain-upgrades.md
+++ b/docs/evm-sidechain/introduction-to-chain-upgrades.md
@@ -1,0 +1,29 @@
+---
+html: introduction-to-chain-upgrades.html
+parent: evm-sidechains.html
+blurb: Learn about XRPL EVM Sidechain upgrades.
+labels:
+  - Development, Interoperability
+status: not_enabled
+---
+
+# Introduction to chain upgrades
+
+Blockchain upgrades are a complex process that requires all network participants to agree on a specific time to execute a specific change in the protocol. Cosmos based networks, like the XRPL EVM Sidechain, solve this complexity with a set of fixed operations that need to happen when  upgrading the chain:
+
+1. A governance proposal containing a chain upgrade transaction is created. This transaction contains specific details of the upgrade such as which block will the upgrade be executed, the version number and some metadata.
+2. Once the proposal is created it is voted as another regular governance proposal.
+3. If the proposal collects enough votes to be approved, the chain upgrade is planned at the block specified.
+4. When the block of the upgrade is minted, all the nodes, that are running the old version will halt, showing an error in the logs notifying the operator to upgrade it to the new binary.
+5. After more than 2/3 of the total validators upgrade their nodes, the chain starts creating new blocks. And the upgrade has finished successfully.
+
+## List of upgrades
+Below is a table indicating all the hard fork upgrades for each network:
+
+<embed src="/snippets/_evm-sidechain-upgrades-table.md" />
+
+## Automated upgrades
+
+In order to automate the manual actions required by node operators during the chain upgrades, we have integrated Cosmovisor. This client automatically detects new binaries for newer versions available and downloads them. Once a new chain upgrade is triggered, the cosmovisor restarts the node with the new binary, reducing the downtime of your node.
+
+Read more in the next section [Install Cosmovisor](install-cosmovisor.md)

--- a/docs/evm-sidechain/join-evm-sidechain-devnet.md
+++ b/docs/evm-sidechain/join-evm-sidechain-devnet.md
@@ -10,10 +10,7 @@ status: not_enabled
 
 <embed src="/snippets/_evm-sidechain-disclaimer.md" />
 
-This tutorial walks you through the steps to join the existing **XRP Ledger EVM Sidechain Devnet**. 
-
-For ease of use, create an alias, `exprd`, to run all commands inside your Docker container.
-
+This tutorial walks you through the steps to install the existing **XRP Ledger EVM Sidechain Devnet**.
 
 ## XRPL EVM Sidechain Node Hardware Requirements
 
@@ -23,21 +20,78 @@ For ease of use, create an alias, `exprd`, to run all commands inside your Docke
 - At least 32GB of RAM.
 - At least 100Mbps network bandwidth.
 
+## Installation Methods
 
-## Pre-requisites
+### Downloading Raw Binaries
 
-Before proceeding to initialize the node, ensure that the following pre-requisites are installed and running:
+A straightforward method that involves downloading the latest binaries and running them on your system. This method requires minimal prerequisites and is quick to set up.
 
-* Docker 19+
-* Create an alias to run all commands in this tutorial inside a Docker container: 
+#### Pre-requisites
 
+- None (Ensure your system meets the hardware requirements).
+
+#### Steps
+
+1. Download the latest binaries from the [official repository](https://github.com/xrplevm/node).
+2. Extract the binaries and move them to your preferred directory.
+3. Make the binaries executable:
     ```bash
-    alias exrpd="docker run -it --rm -v ~/.exrpd:/root/.exrpd --entrypoint=\"\" peersyst/xrp-evm-blockchain:latest exrpd"
+    chmod +x exrpd
     ```
+
+### Building from Source
+
+This method involves cloning the source code repository and building the binaries from source. It is ideal for developers who want to customize the node.
+
+#### Pre-requisites
+
+- `make` and `gcc` installed.
+
+#### Steps
+
+1. Clone the repository:
+    ```bash
+    git clone https://github.com/xrplevm/node.git
+    ```
+2. Navigate to the project directory:
+    ```bash
+    cd node
+    ```
+3. Build the project:
+    ```bash
+    make build
+    ```
+4. The binaries will be available in the `build` directory.
+
+### Using Docker
+
+A containerized approach that ensures the node runs in a consistent environment. This method is highly recommended for users who want to avoid dependency issues.
+
+#### Pre-requisites
+
+- Docker 19+ installed.
+
+#### Steps
+
+1. Pull the Docker image:
+    ```bash
+    docker pull peersyst/exrp:latest
+    ```
+2. Create an alias to run all commands inside the Docker container:
+    ```bash
+    alias exrpd="docker run -it --rm -v ~/.exrpd:/root/.exrpd --entrypoint=\"\" peersyst/exrp:latest exrpd"
+    ```
+
+### Using Cosmovisor for automated upgrades
+
+A more advanced method using Cosmovisor, which automates the process of binary management and upgrades.
+
+For detailed steps, refer to [Using Cosmovisor for automated upgrades](automate-upgrades-using-comsovisor.html).
+
 
 ## Initialize Node
 
-The first task is to initialize the node, which creates the necessary validator and node configuration files. 
+The first task is to initialize the node, which creates the necessary validator and node configuration files.
 
 1. Initialize the chain parameters using the following command:
 
@@ -51,10 +105,9 @@ The first task is to initialize the node, which creates the necessary validator 
     exrpd keys add <key_name> --keyring-backend test
     ```
 
-    Note the `key_name` you enter as you need to reference it in subsequent steps.
+   Note the `key_name` you enter as you need to reference it in subsequent steps.
 
-    **Note** For more information on a more secure setup for your validator, refer to [cosmos-sdk keys and keyrings](https://docs.cosmos.network/v0.46/run-node/keyring.html) and [validator security](evm-sidechain-validator-security.md).
-
+   **Note** For more information on a more secure setup for your validator, refer to [cosmos-sdk keys and keyrings](https://docs.cosmos.network/v0.46/run-node/keyring.html) and [validator security](evm-sidechain-validator-security.md).
 
 3. Initialize the node using the following command:
 
@@ -62,7 +115,7 @@ The first task is to initialize the node, which creates the necessary validator 
     exrpd init <your_custom_moniker> --chain-id exrp_1440002-1
     ```
 
-    Monikers can contain only ASCII characters. Using Unicode characters renders your node unreachable.
+   Monikers can contain only ASCII characters. Using Unicode characters renders your node unreachable.
 
 All these commands create your `~/.exrpd` (i.e `$HOME`) directory with subfolders `config/` and `data/`. In the `config` directory, the most important files for configuration are `app.toml` and `config.toml`.
 
@@ -70,7 +123,7 @@ All these commands create your `~/.exrpd` (i.e `$HOME`) directory with subfol
 
 1. Copy the Genesis File.
 
-    Download the `genesis.json` file from here and copy it to the `config` directory: `~/.exrpd/config/genesis.json`. This is a genesis file with the chain-id and genesis accounts balances.
+   Download the `genesis.json` file from here and copy it to the `config` directory: `~/.exrpd/config/genesis.json`. This is a genesis file with the chain-id and genesis accounts balances.
 
     ```bash
     wget https://raw.githubusercontent.com/Peersyst/xrp-evm-archive/main/poa-devnet/genesis.json -O ~/.exrpd/config/genesis.json
@@ -82,7 +135,7 @@ All these commands create your `~/.exrpd` (i.e `$HOME`) directory with subfol
 
    :::
 
-    Verify the genesis configuration file:
+   Verify the genesis configuration file:
 
     ```bash
     exrpd validate-genesis
@@ -90,80 +143,26 @@ All these commands create your `~/.exrpd` (i.e `$HOME`) directory with subfol
 
 2. Add Persistent Peer Nodes
 
-    Set the [`persistent_peer`](https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#persistent-peer)s field in `~/.exrpd/config/config.toml` to specify peers with which your node maintains persistent connections. You can retrieve them from the list of available peers on the archive repo ([https://raw.githubusercontent.com/Peersyst/xrp-evm-archive/main/poa-devnet/peers.txt](https://raw.githubusercontent.com/Peersyst/xrp-evm-archive/main/devnet/peers.txt)).
+   Set the [`persistent_peer`](https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#persistent-peer)s field in `~/.exrpd/config/config.toml` to specify peers with which your node maintains persistent connections. You can retrieve them from the list of available peers on the archive repo ([https://raw.githubusercontent.com/Peersyst/xrp-evm-archive/main/poa-devnet/peers.txt](https://raw.githubusercontent.com/Peersyst/xrp-evm-archive/main/devnet/peers.txt)).
 
-    To get a list of entries from the `peers.txt` file in the `PEERS` variable, run the following command:
+   To get a list of entries from the `peers.txt` file in the `PEERS` variable, run the following command:
 
     ```bash
     PEERS=`curl -sL https://raw.githubusercontent.com/Peersyst/xrp-evm-archive/main/poa-devnet/peers.txt | sort -R | head -n 10 | awk '{print $1}' | paste -s -d, -`
     ```
 
-    Use `sed` to include them in the configuration. You can also add them manually:
+   Use `sed` to include them in the configuration. You can also add them manually:
 
     ```bash
     sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PEERS\"/" ~/.exrpd/config/config.toml
     ```
- 
+
    At this point you should have the list of the peers copied to the `persistent_peers` field in the `config.toml` file. You can verify this by running the following command:
 
    ```bash
    cat ~/.exrpd/config/config.toml | grep persistent_peers
    ```
 
-## Start a Node
+## Run and Synchronize Your Node
 
- You can start a node container with the following command:
-
- ```bash
- exrpd start
- ```
-
- If you would like to run it in Docker's deamon mode, you can use the following command:
-
-  ```bash
- docker run -d --name=node --entrypoint="" --restart=always -v ~/.exrpd:/root/.exrpd peersyst/xrp-evm-blockchain:latest exrpd start
- ``` 
-
- With this docker command, you will be creating a container with the image `peersyst/xrp-evm-blockchain:latest` 
- that will run in background (`-d` flag) which will be named node (`--name=node`) that will be restarted in the case it stops (`--restart=always flag`) 
- and that will have the folder `~/.exrpd`  mounted in the directory `/root/.exrpd` inside the container.
-
- This command starts the node and begins syncing with the network. You can monitor the progress by watching the logs of the running container
- 
-  ```bash
- docker logs -f <container_id>
-   ```
-
-## Join the Proof of Authority with your node
-
-Similar to the XRPL mainnet, the Devnet runs in a Proof of Authority consensus mechanism. In order to start signing for new blocks and participate in the network consensus, 
-the current validators need to accept your node as a new trusted validator. This democratic process requires the approval of the majority of the current validators.
-
-To begin the process, join the [XRPL EVM Sidechain Discord](https://discord.gg/xrplevm) and introduce yourself in the *`#intros`* channel. Explain who you are and why you want to run a validator. Generally, you will be accepted if you have a real interest in the project, either because you want to use the network for a company, are a recognized member of the community who wants to contribute to its long-term governance, or just have an academic interest.
-
-A proposal to accept your validator will be voted on over a period of 2 days. During this time, some members may write to you publicly or privately to ask more questions. You can view the process on the [XRPL EVM Sidechain Explorer](https://validators.evm-sidechain.xrpl.org/xrp/proposals).
-
-
-### Bond the authority points to your validator
-
-**Warning:** Before proceeding with this step, ensure that:
- - The current validators have accepted your node as a new trusted validator. 
- - You're running the node container and your node is fully synced with the network.
-
-Create a Devnet validator node with this command:
-
-```bash
-exrpd tx staking create-validator \
-  --amount=1000000apoa \
-  --pubkey=$(exrpd tendermint show-validator) \
-  --moniker=<public_name_of_your_node> \
-  --chain-id="exrp_1440002-1" \
-  --commission-rate="0.00" \
-  --commission-max-rate="0.00" \
-  --commission-max-change-rate="0.00" \
-  --min-self-delegation="1000000" \
-  --gas="300000" \
-  --gas-prices="7axrp" \
-  --keyring-backend=<your_keyring> \
-  --from=<your_key>
-```
+To run and synchronize your node, follow the instructions in the [Run and Synchronize Your Node](run-and-synchronize-your-node.md) guide.

--- a/docs/evm-sidechain/join-the-proof-of-authority.md
+++ b/docs/evm-sidechain/join-the-proof-of-authority.md
@@ -1,0 +1,27 @@
+---
+html: join-the-proof-of-authority.html
+parent: evm-sidechains.html
+blurb: Learn how to join the XRPL EVM Sidechain Proof of Authority.
+labels:
+- Validate, Development
+status: not_enabled
+---
+
+# Join the Proof of Authority with your node
+Similar to the XRPL mainnet, the Devnet runs in a Proof of Authority consensus mechanism. In order to start signing for new blocks and participate in the network consensus, the current validators need to accept your node as a new trusted validator. This democratic process requires the approval of the majority of the current validators.
+
+To begin the process, join the [XRPL EVM Sidechain Discord](https://discord.gg/xrplevm) and select your validator role in the `#roles` channel. After that, you will need to introduce yourself in the `#become-a-validator` channel. Explain who you are and why you want to run a validator. Generally, you will be accepted if you have a real interest in the project, either because you want to use the network for a company, are a recognized member of the community who wants to contribute to its long-term governance, or just have an academic interest.
+
+While doing your introduction, you will need to provide the details that identify your validator.
+
+- **Moniker**: The public name of your validator
+- **Validator operator address**: The address of the operator of the node that starts with *ethmvaloper* . Can be obtained by running:
+```bash
+exrpd keys show <key_name> --keyring <keying_backend> --bech val
+```
+- **Public key**: The public key of your node. Can be obtained by running:
+```bash
+exrpd tendermint show-validator
+```
+
+After that, a proposal to accept your validator will be voted on over a period of 7 days. During this time, some members may write to you publicly or privately to ask more questions. You can view the process on the [XRPL EVM Sidechain Explorer](https://governance.xrplevm.org/xrp/proposals).

--- a/docs/evm-sidechain/run-and-synchronize-your-node.md
+++ b/docs/evm-sidechain/run-and-synchronize-your-node.md
@@ -1,0 +1,65 @@
+---
+html: run-and-synchronize-your-node.html
+parent: evm-sidechains.html
+blurb: Learn how to run and synchronize the XRPL EVM Sidechain Devnet node.
+labels:
+- Syncing, Development
+status: not_enabled
+---
+
+# Run and Synchronize your node
+
+This tutorial walks you through the steps to sync the **XRP Ledger EVM Sidechain Devnet**.
+
+## Syncing Options
+
+### Syncing from Genesis
+
+Synchronization from genesis involves starting your node from the very first block of the blockchain and processing all transactions to reach the current state. This method ensures your node has the complete history of the blockchain and is fully up-to-date with all network changes and upgrades.
+
+#### Why Sync from Genesis?
+
+- Ensures your node has the complete transaction history.
+- Verifies all past network upgrades and hard forks.
+- Essential for participating in the network as a full node or validator.
+
+#### Chain Upgrades
+
+To keep your node up-to-date, you need to update the binaries whenever a hard fork occurs. Below is a table indicating all the hard forks for each network:
+
+<embed src="/snippets/_evm-sidechain-upgrades-table.md" />
+
+#### Steps to Sync from Genesis
+
+1. Ensure your node is initialized and configured as per the [Installation Guide](install-evm-sidechain-devnet.html).
+2. Start the node with the initial binary version:
+    ```bash
+    exrpd start
+    ```
+3. Monitor the logs for any errors related to hard forks or network upgrades. When an error like the following happens, update the binary to the next version and repeat step 2 as needed until the node is fully synced with the latest version.
+    ```text
+7:58AM INF Replay last block using real app module=consensus server=node
+7:58AM ERR UPGRADE "v2.0.0" NEEDED at height: 8912879: {"binaries":{"linux/amd64":"https://github.com/Peersyst/exrp/releases/download/v2.0.0/exrp_2.0.0_Linux_amd64.tar.gz","linux/arm64":"https://github.com/Peersyst/exrp/releases/download/v2.0.0/exrp_2.0.0_Linux_arm64.tar.gz","darwin/amd64":"https://github.com/Peersyst/exrp/releases/download/v2.0.0/exrp_2.0.0_Darwin_amd64.tar.gz","darwin/arm64":"https://github.com/Peersyst/exrp/releases/download/v2.0.0/exrp_2.0.0_Darwin_arm64.tar.gz"}}
+panic: UPGRADE "v2.0.0" NEEDED at height: 8912879: {"binaries":{"linux/amd64":"https://github.com/Peersyst/exrp/releases/download/v2.0.0/exrp_2.0.0_Linux_amd64.tar.gz","linux/arm64":"https://github.com/Peersyst/exrp/releases/download/v2.0.0/exrp_2.0.0_Linux_arm64.tar.gz","darwin/amd64":"https://github.com/Peersyst/exrp/releases/download/v2.0.0/exrp_2.0.0_Darwin_amd64.tar.gz","darwin/arm64":"https://github.com/Peersyst/exrp/releases/download/v2.0.0/exrp_2.0.0_Darwin_arm64.tar.gz"}}
+    ```
+
+### Syncing from Snapshot
+
+Syncing from a snapshot involves downloading a recent state of the blockchain, allowing your node to catch up quickly without processing the entire history from the genesis block.
+
+#### Steps to Sync from Snapshot
+
+1. Download a snapshot from a provider that you trust:
+
+| Provider | Type   | Current size | Snapshot URL                                                          |
+|----------|--------|--------------|-----------------------------------------------------------------------|
+| Peersyst | Pruned | >100GB       | https://evm-sidechain-snapshots-devnet.s3.amazonaws.com/exrpd.tar.lz4 |
+
+2. Extract the snapshot to the `data` directory:
+    ```bash
+    tar -xzf exrpd.tar.gz -C ~/.exrpd/data
+    ```
+3. Start the node:
+    ```bash
+    exrpd start
+    ```

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -20,7 +20,14 @@
     - group: Run a Validator
       expanded: false
       pages:
-        - page: docs/evm-sidechain/join-evm-sidechain-devnet.md 
+        - page: docs/evm-sidechain/join-evm-sidechain-devnet.md
+        - page: docs/evm-sidechain/run-and-synchronize-your-node.md
+        - group: Chain upgrades
+          expanded: false
+          pages:
+          - page: docs/evm-sidechain/introduction-to-chain-upgrades.md
+          - page: docs/evm-sidechain/install-cosmovisor.md
+        - page: docs/evm-sidechain/join-the-proof-of-authority.md
         - page: docs/evm-sidechain/manage-the-validator-node.md
         - page: docs/evm-sidechain/evm-sidechain-validator-security.md
     - group: Bridges

--- a/snippets/_evm-sidechain-upgrades-table.md
+++ b/snippets/_evm-sidechain-upgrades-table.md
@@ -1,0 +1,6 @@
+##### Devnet
+
+| Upgrade Name | Block Height | Upgrade Date       | Binary Version                                                              | Docker image                                                                                                                                                                                          |
+|--------------|--------------|--------------------|-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Genesis      | 0            | Initial Deployment | [v1.0.0-beta.0](https://github.com/xrplevm/node/releases/tag/v1.0.0-beta.0) | [peersyst/xrp-evm-blockchain:latest](https://hub.docker.com/layers/peersyst/xrp-evm-blockchain/latest/images/sha256-de9941203bb9f199e6125e3518d9c56a8106c93211cd2840cb9b0fc7652f5416?context=explore) |
+| v2           | 8912879      | 2024-06-05         | [v2.0.0](https://github.com/xrplevm/node/releases/tag/v2.0.0)               | [peersyst/exrp:v2.0.0](https://hub.docker.com/layers/peersyst/exrp/v2.0.0/images/sha256-0e7c502211696f6dae0dc2ce8ae16429bd4ee09941b00cf95e63dfad86d10407?context=explore)                             |


### PR DESCRIPTION
# Changes

1. Split `Join the EVM SIdechain Devnet` into three pieces: `Join the EVM Sidechain Devnet`,  `Run and Synchronize your node` and `Join the Proof of Authority`. This change will allow users understand the difference between installation, synchronization and being part of the Authority.
2. Added chain upgrades missing documentation.
