### PR TITLE
📝 Add new Band Protocol page

### DIFF
--- a/pages/developers/sidebars.yaml
+++ b/pages/developers/sidebars.yaml
@@ -25,6 +25,10 @@
 #   expanded: false
 #   items:
 #     - page: ./advanced-guides/using-a-precompile.md
+- group: Use Oracle Data
+  expanded: false
+  items:
+    - page: ./use-oracle-data/band-protocol.md
 - group: Resources
   expanded: false
   items:

--- a/pages/developers/use-oracle-data/band-protocol.md
+++ b/pages/developers/use-oracle-data/band-protocol.md
@@ -8,7 +8,9 @@
 | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Testnet | [0x8c064bCf7C0DA3B3b090BAbFE8f3323534D84d68](https://explorer.testnet.xrplevm.org/address/0x8c064bCf7C0DA3B3b090BAbFE8f3323534D84d68?tab=contract) |
 
-\*Mainnet address will be listed when available.
+{% admonition type="info" name="Note" %}
+Mainnet address will be listed when available.
+{% /admonition %}
 
 ### How to Use Band Oracle in Your Smart Contracts
 

--- a/pages/developers/use-oracle-data/band-protocol.md
+++ b/pages/developers/use-oracle-data/band-protocol.md
@@ -1,0 +1,25 @@
+# Band Protocol
+
+[Band Protocol](https://www.bandprotocol.com/) is a decentralized, cross-chain data oracle that connects real-world data and APIs to smart contracts. It runs on BandChain, a high-performance blockchain built with the Cosmos SDK, and is designed to support a wide range of blockchain development frameworks.
+
+### Band Oracle Deployment on XRPL EVM Sidechain
+
+| Network | StdReferenceProxy Contract Address                                                                                                                 |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Testnet | [0x8c064bCf7C0DA3B3b090BAbFE8f3323534D84d68](https://explorer.testnet.xrplevm.org/address/0x8c064bCf7C0DA3B3b090BAbFE8f3323534D84d68?tab=contract) |
+
+\*Mainnet address will be listed when available.
+
+### How to Use Band Oracle in Your Smart Contracts
+
+You can fetch real-time price data from Band’s oracle using the StdReferenceProxy contract. Follow the integration steps provided in the repository below:
+
+[https://github.com/bandprotocol/band-std-reference-contracts-solidity](https://github.com/bandprotocol/band-std-reference-contracts-solidity)
+
+### Available Oracle Price Feeds
+
+The following price feeds are currently supported on XRPL EVM Sidechain:
+
+- XRP
+- BTC
+- ETH


### PR DESCRIPTION
## Add Band Protocol Oracle Integration Page to XRPL EVM Sidechain Docs

This PR adds a new documentation page introducing Band Protocol as a supported oracle solution on the XRPL EVM Sidechain.

The page includes:
- Overview of Band Protocol and its role as a decentralized oracle
- Testnet deployment details (StdReferenceProxy contract address)
- Integration steps for smart contract developers
- Available price feeds on XRPL EVM Sidechain
- Reference links to Band’s GitHub and documentation 

**Note**
Please let me know if any structural or formatting changes are needed to align with the XRPL EVM Sidechain doc guidelines. Happy to update as needed!


## Preview Page
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3ffa8f6f-b5be-4bfd-bdf3-7b23888c44db" />
