### PR TITLE
Refresh operator docs (Cosmos EVM 0.6.0): install/sync/upgrade hardening

### DIFF
--- a/pages/operators/advanced/node-configuration-options.md
+++ b/pages/operators/advanced/node-configuration-options.md
@@ -2,6 +2,18 @@
 
 This documentation outlines the various configuration options for nodes in the XRPL EVM sidechain project. Configuring a node correctly is essential for ensuring its intended role within the network. Below, we categorize configuration options into historical data storage, API exposure, and peer exchange configurations.
 
+## Quick reference: which file controls what
+
+Use this quick map before editing settings:
+
+| Setting | File |
+| ------- | ---- |
+| Tendermint/CometBFT RPC (`[rpc].laddr`, port `26657`) | `config.toml` |
+| P2P peer exchange (`[p2p]`) | `config.toml` |
+| Pruning (`pruning`) | `app.toml` |
+| Cosmos API / gRPC (`[api]`, `[grpc]`) | `app.toml` |
+| Ethereum JSON-RPC / WS (`[json-rpc]`) | `app.toml` |
+
 ---
 
 ## Historical Data based configuration

--- a/pages/operators/advanced/sync-options.md
+++ b/pages/operators/advanced/sync-options.md
@@ -6,7 +6,9 @@ The XRPL EVM sidechain supports various synchronization methods for setting up a
 
 Syncing from genesis initializes your `exrpd` node from the very beginning of the XRPL EVM blockchain's history. This method is comprehensive but time-intensive, as it downloads and verifies all blocks and transactions since the chain's inception.
 
-1. **Install `exprd`**: Ensure that the first version of the `exrpd` binary is installed and configured on your system. Refer to the [Networks page](../resources/networks.md) for downloading the first version of the binary for each network and to the [Installation Guide](../getting-started/installing-the-node.md) for detailed setup steps.
+For the full procedure (including Mainnet/Testnet/Devnet version paths and upgrade handling), follow [Sync from Genesis](../getting-started/sync-from-genesis.md).
+
+1. **Install `exrpd`**: Ensure that the first version of the `exrpd` binary is installed and configured on your system. Refer to the [Networks page](../resources/networks.md) for downloading the first version of the binary for each network and to the [Installation Guide](../getting-started/installing-the-node.md) for detailed setup steps.
 
 2. **Start the Node**:
 
@@ -16,6 +18,10 @@ exrpd start
 
 3. **Monitor Progress**:
    Wait for the node to sync until it reaches the block of the next version. Then, upgrade to the newer version and repeat this process until the node is fully in sync with the network. For detailed upgrade instructions, refer to the [Upgrading your node](../guides/upgrading-your-node.md) page.
+
+{% admonition type="warning" name="Validator signer safety" %}
+If this node is a validator signer, keep a **single active validator signer** only. Never run two active instances with the same `~/.exrpd/config/priv_validator_key.json`, and never roll back `~/.exrpd/data/priv_validator_state.json`.
+{% /admonition %}
 
 ## Sync from Snapshot
 

--- a/pages/operators/advanced/sync-options.md
+++ b/pages/operators/advanced/sync-options.md
@@ -32,10 +32,14 @@ Syncing from a snapshot significantly reduces setup time by initializing your no
 2. **Download and decompress the snapshot**:
 
 ```bash
-wget <snapshot_url> -O ~/.exrpd
 cd ~/.exrpd
+wget -O exrpd.tar.lz4 <snapshot_url>
 tar -xI lz4 -f exrpd.tar.lz4
 ```
+
+{% admonition type="warning" name="Validator signer safety" %}
+Do not restore snapshots over an active validator signer home. Snapshot restore is for non-signing nodes or fresh replacement nodes only.
+{% /admonition %}
 
 3. **Start the Node**:
 
@@ -79,4 +83,5 @@ State Sync is an efficient and fast way to bootstrap a new node. It works by rep
      ```
 
 4. **Verify Synchronization**:
-   - Once state sync completes, the node will begin processing blocks normally. If state sync fails with an error such as `state sync aborted`, try restarting `exrpd` or running `exrpd unsafe-reset-all` (ensure you back up any configuration or history before using this command).
+   - Once state sync completes, the node will begin processing blocks normally. If state sync fails with an error such as `state sync aborted`, first restart `exrpd` and verify your `statesync` settings and trusted RPC endpoints.
+   - For non-signing nodes only, you may reset data and retry state sync. Do not run reset commands on active validator signer nodes that hold production `priv_validator_key.json`.

--- a/pages/operators/getting-started/installing-the-node.md
+++ b/pages/operators/getting-started/installing-the-node.md
@@ -1,305 +1,246 @@
 # Installing the Node
 
-The `exrpd` binary is the cornerstone of running an XRPL EVM node. It enables your machine to communicate with the XRPL EVM network, synchronize with the blockchain, and—if configured as a validator—actively participate in consensus. This guide walks you through the process of installing and configuring `exrpd` so you can join the network effectively.
+This guide focuses on the fastest and easiest operator path: install the latest `exrpd`, then bootstrap from a snapshot.
 
-Before proceeding, it’s crucial to understand that node versioning plays a vital role in how you synchronize with the blockchain—especially if you're starting from genesis.
+It covers **Mainnet**, **Testnet**, and **Devnet**, and includes the following run stacks:
 
- The XRPL EVM (Mainnet) initially launched using `exrpd` version 7. At block **497,000**, it upgraded to version 8.0.2. If you intend to sync your node from the very beginning of the chain (i.e., from genesis), you **must** install the same node version used at the network’s genesis—**v7**. Your node will sync until it reaches the block where a version upgrade occurred. At that point, you must manually upgrade your node to the corresponding version (e.g., from v7 to v8.0.2 at block 497,000 to continue syncing without interruption.)
+- `systemctl`
+- `docker`
+- `cosmovisor`
+- installation with raw binaries
+- installation from source
 
- The XRPL EVM Testnet initially launched using `exrpd` version 6. At block **547,100**, it upgraded to version 7, then to version 8 at block **1,485,600** and later to v9.0.0 at block **3,827,000**. If you intend to sync your node from the very beginning of the chain (i.e., from genesis), you **must** install the same node version used at the network’s genesis—**v6**. Your node will sync until it reaches the block where a version upgrade occurred. At that point, you must manually upgrade your node to the corresponding version (e.g., from v6 to v7 at block 547,100, from v7 to v8 at block 1,485,600 and from v8 to v9 at block 3,827,000) to continue syncing without interruption.
+If you specifically need full historical replay from block 0, use [Sync from Genesis](./sync-from-genesis.md).
 
-Alternatively, if syncing from genesis is not required, you can take a more efficient approach by starting from [**sync from snapshot**](https://docs.xrplevm.org/pages/operators/advanced/sync-options#sync-from-snapshot) or using [**sync from state sync**](https://docs.xrplevm.org/pages/operators/advanced/sync-options#state-sync), which allows you to join the network at a later state. In this case, you can install the [**latest version**](../resources/networks.md) of `exrpd` and bypass the need for version hopping altogether.
+## Network reference
 
-{% admonition type="info" name="List of upgrades" %}
-For a detailed list of XRPL EVM network versions—including timestamps, upgrade blocks, and version changes across all supported chains—refer to the official network documentation: [XRPL EVM Networks Overview](../resources/networks.md).
+| Network | Chain ID | Current Version | Genesis |
+| ------- | -------- | --------------- | ------- |
+| Mainnet | `xrplevm_1440000-1` | `v10.0.2` | [Genesis](https://raw.githubusercontent.com/xrplevm/networks/refs/heads/main/mainnet/genesis.json) |
+| Testnet | `xrplevm_1449000-1` | `v10.0.1` | [Genesis](https://raw.githubusercontent.com/xrplevm/networks/refs/heads/main/testnet/genesis.json) |
+| Devnet | `xrplevm_1449900-1` | `v9.0.3` | [Genesis](https://raw.githubusercontent.com/xrplevm/networks/refs/heads/main/devnet/genesis.json) |
+
+## Recommended flow (snapshot-first)
+
+1. Install `exrpd` (raw binary or from source).
+2. Initialize and configure your node for the target network.
+3. Restore snapshot data (when available).
+4. Run the node with `systemctl`, `cosmovisor`, or `docker`.
+
+{% admonition type="info" name="Snapshot availability" %}
+Public snapshot providers are currently listed for Mainnet and Testnet in [Snapshots](../resources/snapshots.md). If a Devnet snapshot is not published, use [State Sync](../advanced/sync-options.md#state-sync) or [Sync from Genesis](./sync-from-genesis.md).
 {% /admonition %}
 
-## Installation Methods
+## 1) Install `exrpd`
 
-There are multiple ways to install the `exrpd` binary on your system. Choose the method that best suits your requirements and expertise.
+### Method A: Raw binary (recommended for most operators)
 
----
+```bash
+cd /tmp
+LATEST_TAG=$(curl -s https://api.github.com/repos/xrplevm/node/releases/latest | grep '"tag_name"' | head -1 | cut -d '"' -f4)
+wget "https://github.com/xrplevm/node/releases/download/${LATEST_TAG}/node_${LATEST_TAG#v}_Linux_amd64.tar.gz"
+tar -xzf "node_${LATEST_TAG#v}_Linux_amd64.tar.gz"
+sudo mv bin/exrpd /usr/local/bin/exrpd
+sudo chmod +x /usr/local/bin/exrpd
+exrpd version
+```
 
-## Method 1: Downloading Raw Binaries
+### Method B: Build from source
 
-This method involves downloading precompiled binaries from the repository's latest release and running them on your system. It’s quick to set up and requires minimal prerequisites.
-
-### Pre-requisites
-
-- **None:** Just ensure your system meets the hardware requirements.
-
-### Steps
-
-1. **Download the Latest Binaries:**  
-   Visit the [official repository's releases page](https://github.com/xrplevm/node/releases) and download the binary that corresponds to your operating system and architecture. You can use `wget` (or `curl` for Windows) to download the file directly from the command line.
-
-   {% tabs %}
-   {% tab label="Linux" %}
-   **For Linux Users:**
-
-   - **AMD64:**  
-     ```bash
-     wget https://github.com/xrplevm/node/releases/download/v7.0.0/node_7.0.0_Linux_amd64.tar.gz
-     ```
-   - **ARM64:**  
-     ```bash
-     wget https://github.com/xrplevm/node/releases/download/v7.0.0/node_7.0.0_Linux_arm64.tar.gz
-     ```
-   {% /tab %}
-
-   {% tab label="macOS" %}
-   **For macOS Users:**
-
-   - **Intel (x86_64):**  
-     ```bash
-     wget https://github.com/xrplevm/node/releases/download/v7.0.0/node_7.0.0_Darwin_amd64.tar.gz
-     ```
-   - **Apple Silicon (ARM64):**  
-     ```bash
-     wget https://github.com/xrplevm/node/releases/download/v7.0.0/node_7.0.0_Darwin_arm64.tar.gz
-     ```
-   {% /tab %}
-   
-   {% tab label="Windows" %}
-   **For Windows Users:**
-
-   Windows doesn't include `wget` by default. Instead, you can use `curl` (available in Windows 10 and later) to download the file:
-   
-   - **Download using curl:**  
-     Open PowerShell and run:
-     ```powershell
-     curl -LO https://github.com/xrplevm/node/releases/download/v7.0.0/node_7.0.0_Windows_amd64.zip
-     ```
-   {% /tab %}
-   {% /tabs %}
-
-2. **Extract the Binaries:**  
-   Once downloaded, extract the file using the appropriate command for your platform. For example, on Linux:
-   ```bash
-   tar -xzf node_7.0.0_Linux_amd64.tar.gz
-   ```
-   This will extract the files into a directory.
-
-3. **Move the Binaries:**  
-   Move the extracted files (especially the `exrpd` binary) to your preferred directory. For instance, to place it in `/usr/local/bin` (which is typically in your PATH), run:
-   ```bash
-   sudo mv /root/bin/exrpd /usr/local/bin/
-   ```
-
-4. **Make the Binary Executable:**  
-   Ensure the binary has executable permissions:
-   ```bash
-   chmod +x /usr/local/bin/exrpd
-   ```
-      - The **exrpd binary** is now located in `/usr/local/bin/exrpd` (if you followed the installation steps).
-   - When you run `exrpd` from the terminal, your system finds it in `/usr/local/bin`.
-
-   You can verify its location by running:
-   ```bash
-   which exrpd
-   ```
-
-   Additionally, once you start your node, configuration files (if created) will be placed in your home directory under `~/.exrpd`.
-
-5. **Verify the Installation:**  
-   Check that the binary is accessible and working by running:
-   ```bash
-   exrpd version
-   ```
-   You should see version information (e.g., `v7.0.0`).
-
-6. **Configure and Run Your Node (Optional):**  
-   Once the binary is installed, follow the [node configuration instructions](./join-the-xrplevm.md)
-
-
-Using this method, you can quickly set up your node by downloading the latest release from the [repository](https://github.com/xrplevm/node/releases).
-
----
-
-## Method 2: Building from Source
-
-This method involves cloning the source code repository and building the binaries from source. It is ideal for developers who want to customize the node.
-
-### Pre-requisites
-
-- `go v1.23.4`, `make` and `gcc` installed.
-
-#### Install Dependencies for Building from Source
-
-{% tabs %}
-{% tab label="Linux" %}
-Install **make** and **gcc**:
 ```bash
 sudo apt-get update
-sudo apt-get install build-essential
+sudo apt-get install -y build-essential git jq curl wget
+
+git clone https://github.com/xrplevm/node.git
+cd node
+make build
+sudo mv build/exrpd /usr/local/bin/exrpd
+sudo chmod +x /usr/local/bin/exrpd
+exrpd version
 ```
-Install **Go v1.23.4**:
+
+### Check Go version against upstream `go.mod`
+
+If you build from source, ensure your local Go version matches what the node currently requires:
+
 ```bash
-sudo rm -rf /usr/local/go
-wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.23.4.linux-amd64.tar.gz
-echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.profile
-source ~/.profile
+REQUIRED_GO=$(curl -fsSL https://raw.githubusercontent.com/xrplevm/node/main/go.mod | awk '/^go /{print $2; exit}')
+echo "Required Go: ${REQUIRED_GO}"
 go version
 ```
-{% /tab %}
-{% tab label="macOS" %}
-Install Xcode Command Line Tools (includes **make** and **gcc**):
+
+If your installed Go version is older than `REQUIRED_GO`, upgrade Go before compiling.
+
+## 2) Initialize and configure for your network
+
+{% tabs %}
+
+{% tab label="Mainnet" %}
 ```bash
-xcode-select --install
-```
-Install **Go v1.23.4** using Homebrew:
-```bash
-brew uninstall go
-brew install go@1.23.4
-```
-Ensure the correct Go binary is in your PATH:
-```bash
-export PATH="/usr/local/opt/go@1.23.4/bin:$PATH"
-go version
+exrpd config set client chain-id xrplevm_1440000-1
+exrpd init <moniker> --chain-id xrplevm_1440000-1
+wget -O ~/.exrpd/config/genesis.json https://raw.githubusercontent.com/xrplevm/networks/refs/heads/main/mainnet/genesis.json
+PEERS=$(curl -sL https://raw.githubusercontent.com/xrplevm/networks/main/mainnet/peers.txt | sort -R | head -n 10 | paste -sd, -)
+sed -i.bak -e "s/^seeds *=.*/seeds = \"${PEERS}\"/" ~/.exrpd/config/config.toml
 ```
 {% /tab %}
-{% tab label="Windows" %}
-**Note:** Building from source on Windows directly can be challenging due to the lack of native support for `make` and `gcc`. It is recommended to use [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install) and then follow the Linux instructions.
+
+{% tab label="Testnet" %}
+```bash
+exrpd config set client chain-id xrplevm_1449000-1
+exrpd init <moniker> --chain-id xrplevm_1449000-1
+wget -O ~/.exrpd/config/genesis.json https://raw.githubusercontent.com/xrplevm/networks/refs/heads/main/testnet/genesis.json
+PEERS=$(curl -sL https://raw.githubusercontent.com/xrplevm/networks/main/testnet/peers.txt | sort -R | head -n 10 | paste -sd, -)
+sed -i.bak -e "s/^seeds *=.*/seeds = \"${PEERS}\"/" ~/.exrpd/config/config.toml
+```
 {% /tab %}
+
+{% tab label="Devnet" %}
+```bash
+exrpd config set client chain-id xrplevm_1449900-1
+exrpd init <moniker> --chain-id xrplevm_1449900-1
+wget -O ~/.exrpd/config/genesis.json https://raw.githubusercontent.com/xrplevm/networks/refs/heads/main/devnet/genesis.json
+PEERS=$(curl -sL https://raw.githubusercontent.com/xrplevm/networks/main/devnet/peers.txt | sort -R | head -n 10 | paste -sd, -)
+sed -i.bak -e "s/^seeds *=.*/seeds = \"${PEERS}\"/" ~/.exrpd/config/config.toml
+```
+{% /tab %}
+
 {% /tabs %}
 
-### Steps to Build the Node
+## 3) Restore snapshot data
 
-1. **Clone the repository:**
-   ```bash
-   git clone https://github.com/xrplevm/node.git
-   ```
-2. **Navigate to the project directory:**
-   ```bash
-   cd node
-   ```
-3. **Build the project:**
-   ```bash
-   make build
-   ```
-4. **Locate the Binaries:**  
-   The compiled binaries will be available in the `build` directory.
+{% tabs %}
 
----
-
-## Method 3: Using Docker
-
-A containerized approach ensures a consistent environment and avoids host-dependency issues. With version **v7.0.0**, you only need **two** Docker commands:
-
-### Prerequisites
-
-* Docker 19+ installed on your host.
-* Run as root (or via sudo) so that `/root/.exrpd` is writable.
-
-### 1. Interactive setup (one-time)
-
-Launch a shell in the container, mounting your host’s config directory. Inside, run **all** of the “Join the XRPL EVM” commands (chain-ID, keygen, init, genesis download, seed configuration, etc.) as per the Mainnet or Testnet guide—then exit when done.
+{% tab label="Mainnet" %}
+Use any provider from [Snapshots](../resources/snapshots.md) and extract into `~/.exrpd`:
 
 ```bash
-docker run -it --name xrplevm-setup \
-  -v /root/.exrpd:/root/.exrpd \
-  peersyst/exrp:7.0.0 \
-  /bin/sh
+cd ~/.exrpd
+wget -O exrpd.tar.lz4 https://evm-sidechain-snapshots-mainnet.s3.us-east-1.amazonaws.com/exrpd.tar.lz4
+tar -xI lz4 -f exrpd.tar.lz4
+```
+{% /tab %}
+
+{% tab label="Testnet" %}
+Use any provider from [Snapshots](../resources/snapshots.md) and extract into `~/.exrpd`:
+
+```bash
+cd ~/.exrpd
+wget -O exrpd.tar.lz4 https://evm-sidechain-snapshots-testnet.s3.us-east-1.amazonaws.com/exrpd.tar.lz4
+tar -xI lz4 -f exrpd.tar.lz4
+```
+{% /tab %}
+
+{% tab label="Devnet" %}
+If no public Devnet snapshot is available, use [State Sync](../advanced/sync-options.md#state-sync) or [Sync from Genesis](./sync-from-genesis.md).
+{% /tab %}
+
+{% /tabs %}
+
+## 4) Run the node
+
+### Option A: `systemctl` (recommended)
+
+Create `/etc/systemd/system/exrpd.service`:
+
+```ini
+[Unit]
+Description=XRPL EVM Node (exrpd)
+After=network-online.target
+
+[Service]
+User=root
+ExecStart=/usr/local/bin/exrpd start
+Restart=always
+RestartSec=3
+LimitNOFILE=65535
+
+[Install]
+WantedBy=multi-user.target
 ```
 
-*(Inside that shell, complete the join-the-xrplevm steps from the docs, then `exit`.)*
+Start it:
 
----
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable exrpd
+sudo systemctl start exrpd
+sudo journalctl -u exrpd -f
+```
 
-### 2. Detached, auto-restarting run
+### Option B: `cosmovisor` + `systemctl`
 
-Now start your fully-configured node in the background. The `--entrypoint` override ensures that `exrpd start` actually runs:
+Install and prepare layout:
+
+```bash
+go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
+mkdir -p ~/.exrpd/cosmovisor/genesis/bin
+cp /usr/local/bin/exrpd ~/.exrpd/cosmovisor/genesis/bin/exrpd
+chmod +x ~/.exrpd/cosmovisor/genesis/bin/exrpd
+ln -sfn ~/.exrpd/cosmovisor/genesis ~/.exrpd/cosmovisor/current
+```
+
+Create `/etc/systemd/system/cosmovisor-exrpd.service`:
+
+```ini
+[Unit]
+Description=XRPL EVM Node (Cosmovisor)
+After=network-online.target
+
+[Service]
+User=root
+Environment="DAEMON_NAME=exrpd"
+Environment="DAEMON_HOME=/root/.exrpd"
+Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
+Environment="UNSAFE_SKIP_BACKUP=true"
+ExecStart=/root/go/bin/cosmovisor run start
+Restart=always
+RestartSec=3
+LimitNOFILE=65535
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Start it:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable cosmovisor-exrpd
+sudo systemctl start cosmovisor-exrpd
+sudo journalctl -u cosmovisor-exrpd -f
+```
+
+For upgrade operations and safer backup settings, follow [Upgrading your node](../guides/upgrading-your-node.md).
+
+### Option C: `docker`
 
 ```bash
 docker run -d \
-  --restart unless-stopped \
   --name xrplevm-node \
+  --restart unless-stopped \
   -v /root/.exrpd:/root/.exrpd \
   --entrypoint exrpd \
-  peersyst/exrp:v7.0.0 \
+  peersyst/exrp:latest \
   start
-```
 
----
-
-### Verification
-
-```bash
-docker ps | grep xrplevm-node
 docker logs -f xrplevm-node
 ```
 
-You should see your node’s Tendermint/exrpd startup logs and syncing progress.
-
-### Upgrade the node
-
-To upgrade your running XRPL EVM node from v7.0.0 to v8.0.2 in Docker, you just need to pull the new image, stop & remove the old container, and re-run it with the same volume mount. Here’s a concise step‐by‐step:
-
-1. **Pull the v8.0.2 image**
-
-   ```bash
-   docker pull peersyst/exrp:v8.0.2
-   ```
-
-2. **Stop and remove your old container**
-
-   ```bash
-   docker stop xrplevm-node
-   docker rm xrplevm-node
-   ```
-
-3. **Run the container with the new tag**
-
-   ```bash
-   docker run -d \
-     --restart unless-stopped \
-     --name xrplevm-node \
-     -v /root/.exrpd:/root/.exrpd \
-     --entrypoint exrpd \
-     peersyst/exrp:v8.0.2 \
-     start
-   ```
-
-   * You’re re-using the same `/root/.exrpd` data directory, so your ledger state stays intact.
-   * The `--entrypoint exrpd … start` invocation is exactly the same as before, just pointing to the new image.
-
-4. **Verify it’s running and has upgraded**
-
-   ```bash
-   docker logs -f --tail 50 xrplevm-node
-   ```
-
-   You should no longer see the `UPGRADE "v8.0.2" NEEDED at height` error and your node will proceed to sync/replay under the new binary.
-
----
-
-### If you’re using Docker Compose
-
-If you prefer `docker-compose.yml`, just change the image tag and do a `docker-compose up -d`:
-
-```yaml
-version: '3.8'
-services:
-  xrplevm-node:
-    image: peersyst/exrp:v8.0.2
-    container_name: xrplevm-node
-    entrypoint: ["exrpd", "start"]
-    restart: unless-stopped
-    volumes:
-      - /root/.exrpd:/root/.exrpd
-```
-
-Then:
+## Validation
 
 ```bash
-docker-compose pull xrplevm-node
-docker-compose up -d xrplevm-node
+exrpd status
+curl -s localhost:26657/status | jq .result.sync_info
 ```
 
-That’s it—your node will now run v8.0.2 and continue syncing from height 547100 onward.
+{% admonition type="warning" name="Validator signer safety" %}
+If this node is a validator signer, keep a **single active validator signer** only. Never run two active instances with the same `~/.exrpd/config/priv_validator_key.json`, and never roll back `~/.exrpd/data/priv_validator_state.json`.
+{% /admonition %}
 
-Do the same with future versions when they launch.
+## Next steps
 
-If you don't want to sync from genesis you can also install the v8.0.2 directly and [**sync from snapshot**](https://docs.xrplevm.org/pages/operators/advanced/sync-options#sync-from-snapshot) or [**sync from state sync**](https://docs.xrplevm.org/pages/operators/advanced/sync-options#state-sync).
+- [Join the XRPL EVM](./join-the-xrplevm.md)
+- [Sync from Genesis](./sync-from-genesis.md)
+- [Sync options](../advanced/sync-options.md)
 

--- a/pages/operators/getting-started/installing-the-node.md
+++ b/pages/operators/getting-started/installing-the-node.md
@@ -1,6 +1,6 @@
 # Installing the Node
 
-This guide focuses on the fastest and easiest operator path: install the latest `exrpd`, then bootstrap from a snapshot.
+This guide focuses on the fastest and easiest operator path: install a network-compatible `exrpd` release, then bootstrap from a snapshot.
 
 It covers **Mainnet**, **Testnet**, and **Devnet**, and includes the following run stacks:
 
@@ -33,35 +33,36 @@ Public snapshot providers are currently listed for Mainnet and Testnet in [Snaps
 
 ## 1) Install `exrpd`
 
+### Prerequisites
+
+Install required tools first:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y curl wget jq lz4 build-essential git rsync
+```
+
 ### Method A: Raw binary (recommended for most operators)
 
 ```bash
 cd /tmp
-LATEST_TAG=$(curl -s https://api.github.com/repos/xrplevm/node/releases/latest | grep '"tag_name"' | head -1 | cut -d '"' -f4)
-wget "https://github.com/xrplevm/node/releases/download/${LATEST_TAG}/node_${LATEST_TAG#v}_Linux_amd64.tar.gz"
-tar -xzf "node_${LATEST_TAG#v}_Linux_amd64.tar.gz"
+TARGET_TAG=<target-tag>
+wget "https://github.com/xrplevm/node/releases/download/${TARGET_TAG}/node_${TARGET_TAG#v}_Linux_amd64.tar.gz"
+tar -xzf "node_${TARGET_TAG#v}_Linux_amd64.tar.gz"
 sudo mv bin/exrpd /usr/local/bin/exrpd
 sudo chmod +x /usr/local/bin/exrpd
 exrpd version
 ```
 
+Set `<target-tag>` from [Networks](../resources/networks.md) for your network:
+
+- Mainnet: `v10.0.2`
+- Testnet: `v10.0.1`
+- Devnet: `v9.0.3`
+
 ### Method B: Build from source
 
-```bash
-sudo apt-get update
-sudo apt-get install -y build-essential git jq curl wget
-
-git clone https://github.com/xrplevm/node.git
-cd node
-make build
-sudo mv build/exrpd /usr/local/bin/exrpd
-sudo chmod +x /usr/local/bin/exrpd
-exrpd version
-```
-
-### Check Go version against upstream `go.mod`
-
-If you build from source, ensure your local Go version matches what the node currently requires:
+If you build from source, check the required Go version in upstream `go.mod` before compiling:
 
 ```bash
 REQUIRED_GO=$(curl -fsSL https://raw.githubusercontent.com/xrplevm/node/main/go.mod | awk '/^go /{print $2; exit}')
@@ -71,7 +72,32 @@ go version
 
 If your installed Go version is older than `REQUIRED_GO`, upgrade Go before compiling.
 
+```bash
+sudo apt-get update
+sudo apt-get install -y golang-go
+
+git clone https://github.com/xrplevm/node.git
+cd node
+make build
+sudo mv build/exrpd /usr/local/bin/exrpd
+sudo chmod +x /usr/local/bin/exrpd
+exrpd version
+```
+
 ## 2) Initialize and configure for your network
+
+{% admonition type="warning" name="Mandatory EVM chain-id setting (v10+)" %}
+Before starting the node, set `evm-chain-id` under `[evm]` in `app.toml`:
+
+- Mainnet: `evm-chain-id = "1440000"`
+- Testnet: `evm-chain-id = "1449000"`
+
+File path (depending on your node home): `~/.exrpd/config/app.toml` or `/var/lib/exrpd/.exrpd/config/app.toml`.
+{% /admonition %}
+
+{% admonition type="warning" name="Validator signer safety" %}
+If this node is an active validator signer, do not re-run `exrpd init` on an existing signer home and do not replace signer state from snapshots. Use one active signer only and preserve `~/.exrpd/data/priv_validator_state.json`.
+{% /admonition %}
 
 {% tabs %}
 
@@ -109,6 +135,10 @@ sed -i.bak -e "s/^seeds *=.*/seeds = \"${PEERS}\"/" ~/.exrpd/config/config.toml
 
 ## 3) Restore snapshot data
 
+{% admonition type="warning" name="Signer role restriction" %}
+Snapshot restore is for bootstrapping non-signing nodes (or fresh replacement nodes) only. For active validator signer nodes, do not overwrite chain state with snapshot restore.
+{% /admonition %}
+
 {% tabs %}
 
 {% tab label="Mainnet" %}
@@ -119,6 +149,8 @@ cd ~/.exrpd
 wget -O exrpd.tar.lz4 https://evm-sidechain-snapshots-mainnet.s3.us-east-1.amazonaws.com/exrpd.tar.lz4
 tar -xI lz4 -f exrpd.tar.lz4
 ```
+
+If this URL is temporarily unavailable, use another provider from [Snapshots](../resources/snapshots.md) and follow that provider's archive format (`.tar.lz4` or `.tar.zst`) and extraction command.
 {% /tab %}
 
 {% tab label="Testnet" %}
@@ -129,6 +161,8 @@ cd ~/.exrpd
 wget -O exrpd.tar.lz4 https://evm-sidechain-snapshots-testnet.s3.us-east-1.amazonaws.com/exrpd.tar.lz4
 tar -xI lz4 -f exrpd.tar.lz4
 ```
+
+If this URL is temporarily unavailable, use another provider from [Snapshots](../resources/snapshots.md) and follow that provider's archive format (`.tar.lz4` or `.tar.zst`) and extraction command.
 {% /tab %}
 
 {% tab label="Devnet" %}
@@ -141,6 +175,21 @@ If no public Devnet snapshot is available, use [State Sync](../advanced/sync-opt
 
 ### Option A: `systemctl` (recommended)
 
+Create a dedicated runtime user (recommended):
+
+```bash
+sudo useradd --system --home /var/lib/exrpd --create-home --shell /usr/sbin/nologin exrpd || true
+sudo mkdir -p /var/lib/exrpd/.exrpd
+sudo chown -R exrpd:exrpd /var/lib/exrpd
+```
+
+Then move your initialized node home to the service path:
+
+```bash
+sudo rsync -a ~/.exrpd/ /var/lib/exrpd/.exrpd/
+sudo chown -R exrpd:exrpd /var/lib/exrpd/.exrpd
+```
+
 Create `/etc/systemd/system/exrpd.service`:
 
 ```ini
@@ -149,11 +198,17 @@ Description=XRPL EVM Node (exrpd)
 After=network-online.target
 
 [Service]
-User=root
-ExecStart=/usr/local/bin/exrpd start
+User=exrpd
+Group=exrpd
+WorkingDirectory=/var/lib/exrpd
+Environment="HOME=/var/lib/exrpd"
+ExecStart=/usr/local/bin/exrpd start --home /var/lib/exrpd/.exrpd
 Restart=always
 RestartSec=3
 LimitNOFILE=65535
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
 
 [Install]
 WantedBy=multi-user.target
@@ -170,14 +225,34 @@ sudo journalctl -u exrpd -f
 
 ### Option B: `cosmovisor` + `systemctl`
 
+Install Go first (required for `go install`):
+
+```bash
+sudo apt-get update
+sudo apt-get install -y golang-go
+```
+
 Install and prepare layout:
 
 ```bash
-go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
-mkdir -p ~/.exrpd/cosmovisor/genesis/bin
-cp /usr/local/bin/exrpd ~/.exrpd/cosmovisor/genesis/bin/exrpd
-chmod +x ~/.exrpd/cosmovisor/genesis/bin/exrpd
-ln -sfn ~/.exrpd/cosmovisor/genesis ~/.exrpd/cosmovisor/current
+sudo env GOBIN=/usr/local/bin go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
+sudo mkdir -p /var/lib/exrpd/.exrpd/cosmovisor/genesis/bin
+sudo cp /usr/local/bin/exrpd /var/lib/exrpd/.exrpd/cosmovisor/genesis/bin/exrpd
+sudo chmod +x /var/lib/exrpd/.exrpd/cosmovisor/genesis/bin/exrpd
+sudo ln -sfn /var/lib/exrpd/.exrpd/cosmovisor/genesis /var/lib/exrpd/.exrpd/cosmovisor/current
+sudo chown -R exrpd:exrpd /var/lib/exrpd/.exrpd
+```
+
+If your restored data includes `upgrade-info.json`, pre-stage the binary for that upgrade name before starting Cosmovisor:
+
+```bash
+UPGRADE_NAME=$(jq -r '.name // empty' /var/lib/exrpd/.exrpd/data/upgrade-info.json 2>/dev/null || true)
+if [ -n "$UPGRADE_NAME" ]; then
+  sudo mkdir -p "/var/lib/exrpd/.exrpd/cosmovisor/upgrades/${UPGRADE_NAME}/bin"
+  sudo cp /usr/local/bin/exrpd "/var/lib/exrpd/.exrpd/cosmovisor/upgrades/${UPGRADE_NAME}/bin/exrpd"
+  sudo chmod +x "/var/lib/exrpd/.exrpd/cosmovisor/upgrades/${UPGRADE_NAME}/bin/exrpd"
+  sudo chown -R exrpd:exrpd /var/lib/exrpd/.exrpd/cosmovisor/upgrades
+fi
 ```
 
 Create `/etc/systemd/system/cosmovisor-exrpd.service`:
@@ -188,15 +263,22 @@ Description=XRPL EVM Node (Cosmovisor)
 After=network-online.target
 
 [Service]
-User=root
+User=exrpd
+Group=exrpd
+WorkingDirectory=/var/lib/exrpd
 Environment="DAEMON_NAME=exrpd"
-Environment="DAEMON_HOME=/root/.exrpd"
+Environment="DAEMON_HOME=/var/lib/exrpd/.exrpd"
 Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
-Environment="UNSAFE_SKIP_BACKUP=true"
-ExecStart=/root/go/bin/cosmovisor run start
+Environment="UNSAFE_SKIP_BACKUP=false"
+Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
+Environment="HOME=/var/lib/exrpd"
+ExecStart=/usr/local/bin/cosmovisor run start --home /var/lib/exrpd/.exrpd
 Restart=always
 RestartSec=3
 LimitNOFILE=65535
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
 
 [Install]
 WantedBy=multi-user.target
@@ -211,21 +293,40 @@ sudo systemctl start cosmovisor-exrpd
 sudo journalctl -u cosmovisor-exrpd -f
 ```
 
+With `UNSAFE_SKIP_BACKUP=false`, first start may take several minutes while Cosmovisor creates a full data backup before restart.
+
 For upgrade operations and safer backup settings, follow [Upgrading your node](../guides/upgrading-your-node.md).
 
 ### Option C: `docker`
 
+Install Docker first if it is not available:
+
 ```bash
+sudo apt-get update
+sudo apt-get install -y docker.io
+sudo systemctl enable --now docker
+```
+
+```bash
+TARGET_TAG=<target-tag>
+
+# Make RPC reachable through -p 26657:26657
+# Note: this RPC listener is in config.toml ([rpc].laddr), not app.toml.
+sed -i.bak -E 's#^laddr = "tcp://127.0.0.1:26657"#laddr = "tcp://0.0.0.0:26657"#' ~/.exrpd/config/config.toml
+
 docker run -d \
   --name xrplevm-node \
   --restart unless-stopped \
+  -p 26657:26657 \
   -v /root/.exrpd:/root/.exrpd \
   --entrypoint exrpd \
-  peersyst/exrp:latest \
+  peersyst/exrp:${TARGET_TAG} \
   start
 
 docker logs -f xrplevm-node
 ```
+
+Use the exact `<target-tag>` from [Networks](../resources/networks.md) (for example, Mainnet `v10.0.2`).
 
 ## Validation
 
@@ -236,6 +337,10 @@ curl -s localhost:26657/status | jq .result.sync_info
 
 {% admonition type="warning" name="Validator signer safety" %}
 If this node is a validator signer, keep a **single active validator signer** only. Never run two active instances with the same `~/.exrpd/config/priv_validator_key.json`, and never roll back `~/.exrpd/data/priv_validator_state.json`.
+{% /admonition %}
+
+{% admonition type="info" name="Operator security note" %}
+For signer nodes, avoid `exrpd unsafe-reset-all`, snapshot overwrite on active signer data, and parallel runtime stacks (for example `systemctl` plus `docker`) using the same validator key.
 {% /admonition %}
 
 ## Next steps

--- a/pages/operators/getting-started/join-the-xrplevm.md
+++ b/pages/operators/getting-started/join-the-xrplevm.md
@@ -43,6 +43,12 @@ Adjust other recommended settings:
 - **API Access**: Disable all except Tendermint RPC (restrict to localhost)
 - **Peer Exchange**: Keep default unless specific network config is required
 
+{% admonition type="warning" name="Mandatory EVM chain-id setting (v10+)" %}
+Before starting the Mainnet node, set `evm-chain-id = "1440000"` under `[evm]` in `app.toml`.
+
+File path (depending on your node home): `~/.exrpd/config/app.toml` or `/var/lib/exrpd/.exrpd/config/app.toml`.
+{% /admonition %}
+
 For more details, refer to the [node configuration documentation](https://docs.xrplevm.org/pages/operators/advanced/node-configuration-options) as well as the [node configuration reference](https://docs.xrplevm.org/pages/operators/resources/configuration-reference).
 
 ### 4. Create a New Key
@@ -83,7 +89,7 @@ wget -O ~/.exrpd/config/genesis.json https://raw.githubusercontent.com/xrplevm/n
 Add seeds to the node configuration that will allow connecting to the rest of the node. Modify the file `~/.exrpd/config/config.toml` to include the following seed node:
 
 ```sh
-PEERS=`curl -sL https://raw.githubusercontent.com/xrplevm/networks/main/mainnet/peers.txt | sort -R | head -n 10 | awk '{print $1}' | paste -s -d, -`
+PEERS=$(curl -sL https://raw.githubusercontent.com/xrplevm/networks/main/mainnet/peers.txt | sort -R | head -n 10 | awk '{print $1}' | paste -s -d, -)
 sed -i.bak -e "s/^seeds *=.*/seeds = \"$PEERS\"/" ~/.exrpd/config/config.toml
 cat ~/.exrpd/config/config.toml | grep seeds
 ```
@@ -125,6 +131,12 @@ Adjust other recommended settings:
 - **API Access**: Disable all except Tendermint RPC (restrict to localhost)
 - **Peer Exchange**: Keep default unless specific network config is required
 
+{% admonition type="warning" name="Mandatory EVM chain-id setting (v10+)" %}
+Before starting the Testnet node, set `evm-chain-id = "1449000"` under `[evm]` in `app.toml`.
+
+File path (depending on your node home): `~/.exrpd/config/app.toml` or `/var/lib/exrpd/.exrpd/config/app.toml`.
+{% /admonition %}
+
 For more details, refer to the [node configuration documentation](https://docs.xrplevm.org/pages/operators/advanced/node-configuration-options) as well as the [node configuration reference](https://docs.xrplevm.org/pages/operators/resources/configuration-reference).
 
 ### 4. Create a New Key
@@ -165,7 +177,7 @@ wget -O ~/.exrpd/config/genesis.json https://raw.githubusercontent.com/xrplevm/n
 Add seeds to the node configuration that will allow connecting to the rest of the node. Modify the file `~/.exrpd/config/config.toml` to include the following seed node:
 
 ```sh
-PEERS=`curl -sL https://raw.githubusercontent.com/xrplevm/networks/main/testnet/peers.txt | sort -R | head -n 10 | awk '{print $1}' | paste -s -d, -`
+PEERS=$(curl -sL https://raw.githubusercontent.com/xrplevm/networks/main/testnet/peers.txt | sort -R | head -n 10 | awk '{print $1}' | paste -s -d, -)
 sed -i.bak -e "s/^seeds *=.*/seeds = \"$PEERS\"/" ~/.exrpd/config/config.toml
 cat ~/.exrpd/config/config.toml | grep seeds
 ```
@@ -247,7 +259,7 @@ wget -O ~/.exrpd/config/genesis.json https://raw.githubusercontent.com/xrplevm/n
 Add seeds to the node configuration that will allow connecting to the rest of the node. Modify the file `~/.exrpd/config/config.toml` to include the following seed node:
 
 ```sh
-PEERS=`curl -sL https://raw.githubusercontent.com/xrplevm/networks/main/devnet/peers.txt | sort -R | head -n 10 | awk '{print $1}' | paste -s -d, -`
+PEERS=$(curl -sL https://raw.githubusercontent.com/xrplevm/networks/main/devnet/peers.txt | sort -R | head -n 10 | awk '{print $1}' | paste -s -d, -)
 sed -i.bak -e "s/^seeds *=.*/seeds = \"$PEERS\"/" ~/.exrpd/config/config.toml
 cat ~/.exrpd/config/config.toml | grep seeds
 ```
@@ -261,8 +273,8 @@ Once your configuration is complete, start the node using your preferred process
 
 ```sh
 # Example using systemd:
-systemctl enable exrpd
-systemctl start exrpd
+sudo systemctl enable exrpd
+sudo systemctl start exrpd
 
 # Or, using Docker:
 docker start xrplevm-node

--- a/pages/operators/getting-started/join-the-xrplevm.md
+++ b/pages/operators/getting-started/join-the-xrplevm.md
@@ -1,6 +1,6 @@
 # Join the XRPL EVM
 
-Now that you have successfully installed the `exrpd` binary, it’s time to take the next steps and fully connect to the XRPL EVM. This page provides separate instructions for **Mainnet** and **Testnet**. Pick the environment you want to join and follow the steps in that tab.
+Now that you have successfully installed the `exrpd` binary, it’s time to take the next steps and fully connect to the XRPL EVM. This page provides separate instructions for **Mainnet**, **Testnet**, and **Devnet**. Pick the environment you want to join and follow the steps in that tab.
 
 ## Prerequisites
 
@@ -171,30 +171,116 @@ cat ~/.exrpd/config/config.toml | grep seeds
 ```
 
 {% /tab %}
+
+{% tab label="Devnet" %}
+
+## Devnet Setup
+
+The following guide outlines the steps for any participant to launch or join the **XRPL EVM Devnet**.
+
+### 1. Infrastructure Provision
+
+Provision a new machine with stable connectivity and enough resources to run the node. Refer to the XRPL EVM documentation for [minimum specifications](./system-requirements.md).
+
+### 2. Node Installation
+
+Download and install the XRPL EVM node binary using the official instructions:  
+[Installing the Node](./installing-the-node.md)
+
+### 3. Configure the Node
+
+Set up the node configuration with the **Devnet** chain ID:
+
+```bash
+exrpd config set client chain-id xrplevm_1449900-1
+```
+
+Choose a secure keyring backend:
+
+```bash
+exrpd config set client keyring-backend <keyring>
+```
+
+Adjust other recommended settings:
+
+- **Pruning**: Default
+- **API Access**: Disable all except Tendermint RPC (restrict to localhost)
+- **Peer Exchange**: Keep default unless specific network config is required
+
+For more details, refer to the [node configuration documentation](https://docs.xrplevm.org/pages/operators/advanced/node-configuration-options) as well as the [node configuration reference](https://docs.xrplevm.org/pages/operators/resources/configuration-reference).
+
+### 4. Create a New Key
+
+Generate a new validator key:
+
+```bash
+exrpd keys add <key_name> --key-type eth_secp256k1
+```
+
+**Ensure that you back up the mnemonic securely**. Effective [key management](../validators/managing-keys.md) is critical for the security and operation of validators in the XRPL EVM sidechain.
+
+### 5. Initialize the Node
+
+Initialize your node with a moniker (a unique name for your node/validator) and the **Devnet** chain ID:
+
+```bash
+exrpd init <moniker> --chain-id xrplevm_1449900-1
+```
+
+**Ensure that you back up the node keys securely**. [Read more](https://docs.xrplevm.org/pages/operators/validators/managing-keys).
+
+```sh
+~/.exrpd/config/node_key.json
+~/.exrpd/config/priv_validator_key.json
+```
+
+### 6. Download the Genesis File
+
+Fetch the **Devnet** genesis file:
+
+```sh
+wget -O ~/.exrpd/config/genesis.json https://raw.githubusercontent.com/xrplevm/networks/refs/heads/main/devnet/genesis.json
+```
+
+### 7. Add Seeds to the Node Configuration
+
+Add seeds to the node configuration that will allow connecting to the rest of the node. Modify the file `~/.exrpd/config/config.toml` to include the following seed node:
+
+```sh
+PEERS=`curl -sL https://raw.githubusercontent.com/xrplevm/networks/main/devnet/peers.txt | sort -R | head -n 10 | awk '{print $1}' | paste -s -d, -`
+sed -i.bak -e "s/^seeds *=.*/seeds = \"$PEERS\"/" ~/.exrpd/config/config.toml
+cat ~/.exrpd/config/config.toml | grep seeds
+```
+
+{% /tab %}
 {% /tabs %}
 
 ### Start the Node
 
-Once your configuration is complete, start the node using your preferred process manager (e.g., systemd, Docker Compose, or another init system) as outlined in the [Installing the Node](./installing-the-node.md) guide. This ensures the node will run continuously and restart on failure:
+Once your configuration is complete, start the node using your preferred process manager (e.g., systemd via `systemctl`, Docker via `docker`, Cosmovisor, or another init system) as outlined in the [Installing the Node](./installing-the-node.md) guide. This ensures the node will run continuously and restart on failure:
 
 ```sh
 # Example using systemd:
 systemctl enable exrpd
 systemctl start exrpd
 
-# Or, using Docker Compose:
-docker-compose up -d xrplevm-node
-````
+# Or, using Docker:
+docker start xrplevm-node
+```
 
 Monitor the logs to verify syncing:
 
 ```sh
-journalctl -u exrpd -f      # systemd
+journalctl -u exrpd -f      # systemd/systemctl
 # or
 docker logs -f xrplevm-node # Docker
 ```
 
 Once it connects to the majority of validators, blocks will start streaming in and your node will produce data.
+
+{% admonition type="warning" name="Validator safety" %}
+If this node is a validator signer, keep a **single active validator signer** only. Never run two active instances with the same `~/.exrpd/config/priv_validator_key.json`, and never roll back `~/.exrpd/data/priv_validator_state.json`.
+{% /admonition %}
 
 ### Sync the Node
 
@@ -217,3 +303,5 @@ Once your node is fully synced, you can:
 
 - [Upgrade your node](../guides/upgrading-your-node.md) when new releases are available.
 - Customize your node’s behavior in [Node configuration options](../advanced/node-configuration-options.md).
+
+Before any upgrade, follow the validator-safe sequence in [Upgrading your node](../guides/upgrading-your-node.md) to prevent double-signing.

--- a/pages/operators/getting-started/sync-from-genesis.md
+++ b/pages/operators/getting-started/sync-from-genesis.md
@@ -16,7 +16,7 @@ When syncing from genesis, you must start from the network genesis binary and up
 | Genesis      | `0`       | `v7.0.0`       |
 | v8           | `497000`  | `v8.0.2`       |
 | v9           | `4688681` | `v9.0.3`       |
-| v10          | `4749000` | `v9.0.3`       |
+| v10          | `4749000` | `v10.0.2`      |
 
 {% /tab %}
 
@@ -26,7 +26,7 @@ When syncing from genesis, you must start from the network genesis binary and up
 | Genesis      | `0`       | `v6.0.0`       |
 | v7           | `547100`  | `v7.0.0`       |
 | v8           | `1485600` | `v8.0.0`       |
-| v9.          | `3827000` | `v9.0.3`       |
+| v9           | `3827000` | `v9.0.3`       |
 | v10          | `5601606` | `v10.0.1`      |
 {% /tab %}
 
@@ -72,7 +72,7 @@ Run with your preferred stack:
 
 - `systemctl`: `systemctl start exrpd`
 - `cosmovisor`: `systemctl start cosmovisor-exrpd` (or `cosmovisor run start`)
-- `docker`: run container with explicit tag matching current required version
+- `docker`: run container with explicit tag matching the current upgrade stage version
 
 Monitor logs:
 
@@ -87,6 +87,15 @@ docker logs -f xrplevm-node
 ## Step 3: Upgrade when the node halts
 
 At each upgrade height, old binaries halt with an upgrade-needed message. Replace the binary with the target version and restart.
+
+{% admonition type="warning" name="Mandatory EVM chain-id setting (v10+)" %}
+Before starting with a v10+ binary, set `evm-chain-id` under `[evm]` in `app.toml`:
+
+- Mainnet: `evm-chain-id = "1440000"`
+- Testnet: `evm-chain-id = "1449000"`
+
+File path (depending on your node home): `~/.exrpd/config/app.toml` or `/var/lib/exrpd/.exrpd/config/app.toml`.
+{% /admonition %}
 
 {% admonition type="warning" name="Validator signer safety" %}
 If this node is a validator signer, keep a **single active validator signer** only. Never run two active instances with the same `~/.exrpd/config/priv_validator_key.json`, and never roll back `~/.exrpd/data/priv_validator_state.json`.
@@ -120,7 +129,13 @@ sudo systemctl restart cosmovisor-exrpd
 ```bash
 docker pull peersyst/exrp:<new-version>
 docker stop xrplevm-node && docker rm xrplevm-node
+
+# Make RPC reachable through -p 26657:26657
+# Note: this RPC listener is in config.toml ([rpc].laddr), not app.toml.
+sed -i.bak -E 's#^laddr = "tcp://127.0.0.1:26657"#laddr = "tcp://0.0.0.0:26657"#' ~/.exrpd/config/config.toml
+
 docker run -d --name xrplevm-node --restart unless-stopped \
+  -p 26657:26657 \
   -v /root/.exrpd:/root/.exrpd --entrypoint exrpd peersyst/exrp:<new-version> start
 ```
 

--- a/pages/operators/getting-started/sync-from-genesis.md
+++ b/pages/operators/getting-started/sync-from-genesis.md
@@ -1,0 +1,140 @@
+# Sync from Genesis
+
+Use this guide when you need full historical replay from block 0.
+
+For most operators, [Installing the Node](./installing-the-node.md) with snapshot/state-sync is faster and simpler. Genesis sync is slower and requires binary upgrades at specific heights.
+
+## Network upgrade path
+
+When syncing from genesis, you must start from the network genesis binary and upgrade at each hard fork.
+
+{% tabs %}
+
+{% tab label="Mainnet" %}
+| Upgrade Name | Height    | Binary Version |
+| ------------ | --------- | -------------- |
+| Genesis      | `0`       | `v7.0.0`       |
+| v8           | `497000`  | `v8.0.2`       |
+| v9           | `4688681` | `v9.0.3`       |
+| v10          | `4749000` | `v9.0.3`       |
+
+{% /tab %}
+
+{% tab label="Testnet" %}
+| Upgrade Name | Height    | Binary Version |
+| ------------ | --------- | -------------- |
+| Genesis      | `0`       | `v6.0.0`       |
+| v7           | `547100`  | `v7.0.0`       |
+| v8           | `1485600` | `v8.0.0`       |
+| v9.          | `3827000` | `v9.0.3`       |
+| v10          | `5601606` | `v10.0.1`      |
+{% /tab %}
+
+{% tab label="Devnet" %}
+| Upgrade Name | Height | Binary Version |
+| ------------ | ------ | -------------- |
+| Genesis      | `0`    | `v9.0.3`       |
+{% /tab %}
+
+{% /tabs %}
+
+{% admonition type="info" name="Source of truth" %}
+Upgrade schedule and versions are maintained in [Networks](../resources/networks.md).
+{% /admonition %}
+
+## Prerequisites
+
+- `exrpd` installed (raw binary or built from source)
+- Node initialized for your target network
+- Genesis file and peers configured
+- Process manager ready (`systemctl`, `cosmovisor`, or `docker`)
+
+See [Installing the Node](./installing-the-node.md) for install and runtime options.
+
+## Step 1: Install the genesis binary
+
+Install the binary for the **first** version in your network’s upgrade path table.
+
+```bash
+cd /tmp
+wget https://github.com/xrplevm/node/releases/download/v7.0.0/node_7.0.0_Linux_amd64.tar.gz
+tar -xzf node_7.0.0_Linux_amd64.tar.gz
+sudo mv bin/exrpd /usr/local/bin/exrpd
+sudo chmod +x /usr/local/bin/exrpd
+exrpd version
+```
+
+Adjust the version/tag according to your network (for example, Testnet genesis starts at `v6.0.0`).
+
+## Step 2: Start the node and sync
+
+Run with your preferred stack:
+
+- `systemctl`: `systemctl start exrpd`
+- `cosmovisor`: `systemctl start cosmovisor-exrpd` (or `cosmovisor run start`)
+- `docker`: run container with explicit tag matching current required version
+
+Monitor logs:
+
+```bash
+journalctl -u exrpd -f
+# or
+journalctl -u cosmovisor-exrpd -f
+# or
+docker logs -f xrplevm-node
+```
+
+## Step 3: Upgrade when the node halts
+
+At each upgrade height, old binaries halt with an upgrade-needed message. Replace the binary with the target version and restart.
+
+{% admonition type="warning" name="Validator signer safety" %}
+If this node is a validator signer, keep a **single active validator signer** only. Never run two active instances with the same `~/.exrpd/config/priv_validator_key.json`, and never roll back `~/.exrpd/data/priv_validator_state.json`.
+{% /admonition %}
+
+### Raw binary / `systemctl`
+
+```bash
+sudo systemctl stop exrpd
+# replace /usr/local/bin/exrpd with new version
+sudo systemctl start exrpd
+```
+
+### `cosmovisor`
+
+Place the new binary at:
+
+```text
+~/.exrpd/cosmovisor/upgrades/<upgrade-name>/bin/exrpd
+```
+
+Ensure executable permissions and restart if needed:
+
+```bash
+chmod +x ~/.exrpd/cosmovisor/upgrades/<upgrade-name>/bin/exrpd
+sudo systemctl restart cosmovisor-exrpd
+```
+
+### `docker`
+
+```bash
+docker pull peersyst/exrp:<new-version>
+docker stop xrplevm-node && docker rm xrplevm-node
+docker run -d --name xrplevm-node --restart unless-stopped \
+  -v /root/.exrpd:/root/.exrpd --entrypoint exrpd peersyst/exrp:<new-version> start
+```
+
+Repeat until you reach the latest network version.
+
+## Verify sync
+
+```bash
+exrpd status
+curl -s localhost:26657/status | jq .result.sync_info
+```
+
+## Related guides
+
+- [Installing the Node](./installing-the-node.md)
+- [Upgrading your node](../guides/upgrading-your-node.md)
+- [Sync options](../advanced/sync-options.md)

--- a/pages/operators/guides/interacting-with-the-node-cli.md
+++ b/pages/operators/guides/interacting-with-the-node-cli.md
@@ -26,7 +26,7 @@ Use the `config` command to manage node configuration. This is helpful for setti
 
 | Subcommand | Description                                                                                              |
 | ---------- | -------------------------------------------------------------------------------------------------------- |
-| `diff`     | Outputs all config values that differ from the default `app.toml` configuration.                         |
+| `diff`     | Outputs config values that differ from defaults for a given target version and `app.toml` path.          |
 | `get`      | Displays the current value of a specific configuration parameter.                                        |
 | `home`     | Prints the folder used as the binary home directory. _(When using `confix` standalone, no home is set.)_ |
 | `migrate`  | Migrates a Cosmos SDK app configuration file to a specified version.                                     |
@@ -37,7 +37,7 @@ Use the `config` command to manage node configuration. This is helpful for setti
 
 - **Check all deviations from default config:**
   ```
-  exrpd config diff
+  exrpd config diff <target-version> ~/.exrpd/config/app.toml
   ```
 - **Get a specific config value:**
   ```
@@ -49,7 +49,7 @@ Use the `config` command to manage node configuration. This is helpful for setti
   ```
 - **Display current config file contents:**
   ```
-  exrpd config view
+  exrpd config view app
   ```
 
 ## Key Management
@@ -69,6 +69,7 @@ Managing your node’s keys is essential. If you plan to operate a production no
 | `export`                | Export a private key (either encrypted or unencrypted, depending on flags used).     |
 | `import`                | Import a previously exported private key into the local keybase.                     |
 | `list`                  | List all locally stored keys.                                                        |
+| `list-key-types`        | List supported key algorithms available for key creation.                            |
 | `migrate`               | Migrate keys from Amino to Proto serialization format.                               |
 | `mnemonic`              | Generate or compute the BIP39 mnemonic from supplied entropy.                        |
 | `parse`                 | Convert an address between hex and Bech32 encoding.                                  |
@@ -86,6 +87,10 @@ Managing your node’s keys is essential. If you plan to operate a production no
 - **List existing keys:**
   ```
   exrpd keys list
+  ```
+- **List supported key types:**
+  ```
+  exrpd keys list-key-types
   ```
 - **Export a key:**
   ```
@@ -216,7 +221,35 @@ Prints the `exrpd` application’s binary version information. This can be helpf
 exrpd version
 ```
 
+## Other Top-Level Commands
+
+In addition to `config`, `keys`, `query`, and `tx`, the current `exrpd` binary also includes:
+
+- `comet`
+- `debug`
+- `export`
+- `genesis`
+- `index-eth-tx`
+- `init`
+- `prune`
+- `rollback`
+- `snapshots`
+- `start`
+- `status`
+
 ## Quick Reference: Common Node CLI Tasks
+
+Use the correct chain ID for your target network from [Networks](../resources/networks.md) and replace `<chain-id>` in examples below.
+
+{% admonition type="info" name="Execution prerequisites" %}
+Many commands in this section are state-changing transactions and require:
+
+- a funded wallet,
+- a valid `--from` key in your keyring,
+- and a reachable RPC endpoint.
+
+Use `--help` first if you are unsure about required flags.
+{% /admonition %}
 
 This section provides a practical cheat sheet for everyday tasks when working with the `exrpd` CLI. Whether you're managing wallets, staking tokens, operating a validator, or participating in governance, these ready-to-use commands help you move fast and confidently.
 
@@ -279,37 +312,37 @@ exrpd keys import $WALLET wallet.backup
 **Withdraw All Rewards**
 
 ```bash
-exrpd tx distribution withdraw-all-rewards --from $WALLET --chain-id exrp_1440002-1 --gas auto --gas-adjustment 1.5
+exrpd tx distribution withdraw-all-rewards --from $WALLET --chain-id <chain-id> --gas auto --gas-adjustment 1.5
 ```
 
 **Withdraw Rewards + Commission**
 
 ```bash
-exrpd tx distribution withdraw-rewards $VALOPER_ADDRESS --from $WALLET --commission --chain-id exrp_1440002-1 --gas auto --gas-adjustment 1.5 -y
+exrpd tx distribution withdraw-rewards $VALOPER_ADDRESS --from $WALLET --commission --chain-id <chain-id> --gas auto --gas-adjustment 1.5 -y
 ```
 
 **Delegate to Yourself**
 
 ```bash
-exrpd tx staking delegate $(exrpd keys show $WALLET --bech val -a) 1000000uxrp --from $WALLET --chain-id exrp_1440002-1 --gas auto --gas-adjustment 1.5 -y
+exrpd tx staking delegate $(exrpd keys show $WALLET --bech val -a) 1000000uxrp --from $WALLET --chain-id <chain-id> --gas auto --gas-adjustment 1.5 -y
 ```
 
 **Delegate to Another Validator**
 
 ```bash
-exrpd tx staking delegate <TO_VALOPER_ADDRESS> 1000000uxrp --from $WALLET --chain-id exrp_1440002-1 --gas auto --gas-adjustment 1.5 -y
+exrpd tx staking delegate <TO_VALOPER_ADDRESS> 1000000uxrp --from $WALLET --chain-id <chain-id> --gas auto --gas-adjustment 1.5 -y
 ```
 
 **Redelegate Stake**
 
 ```bash
-exrpd tx staking redelegate $VALOPER_ADDRESS <TO_VALOPER_ADDRESS> 1000000uxrp --from $WALLET --chain-id exrp_1440002-1 --gas auto --gas-adjustment 1.5 -y
+exrpd tx staking redelegate $VALOPER_ADDRESS <TO_VALOPER_ADDRESS> 1000000uxrp --from $WALLET --chain-id <chain-id> --gas auto --gas-adjustment 1.5 -y
 ```
 
 **Unbond Tokens**
 
 ```bash
-exrpd tx staking unbond $(exrpd keys show $WALLET --bech val -a) 1000000uxrp --from $WALLET --chain-id exrp_1440002-1 --gas auto --gas-adjustment 1.5 -y
+exrpd tx staking unbond $(exrpd keys show $WALLET --bech val -a) 1000000uxrp --from $WALLET --chain-id <chain-id> --gas auto --gas-adjustment 1.5 -y
 ```
 
 **Transfer Funds**
@@ -336,7 +369,7 @@ exrpd tx staking create-validator \
 --moniker "$MONIKER" \
 --identity "" \
 --details "I love blockchain ❤️" \
---chain-id exrp_1440002-1 \
+--chain-id <chain-id> \
 --gas auto --gas-adjustment 1.5 \
 -y
 ```
@@ -350,7 +383,7 @@ exrpd tx staking edit-validator \
 --identity "" \
 --details "I love blockchain ❤️" \
 --from $WALLET \
---chain-id exrp_1440002-1 \
+--chain-id <chain-id> \
 --gas auto --gas-adjustment 1.5 \
 -y
 ```
@@ -382,7 +415,7 @@ exrpd query slashing params
 **Unjail Validator**
 
 ```bash
-exrpd tx slashing unjail --from $WALLET --chain-id exrp_1440002-1 --gas auto --gas-adjustment 1.5 -y
+exrpd tx slashing unjail --from $WALLET --chain-id <chain-id> --gas auto --gas-adjustment 1.5 -y
 ```
 
 **List Active Validators**
@@ -429,7 +462,7 @@ exrpd query gov proposal 1
 **Vote on a Proposal**
 
 ```bash
-exrpd tx gov vote 1 yes --from $WALLET --chain-id exrp_1440002-1 --gas auto --gas-adjustment 1.5
+exrpd tx gov vote 1 yes --from $WALLET --chain-id <chain-id> --gas auto --gas-adjustment 1.5
 ```
 
 

--- a/pages/operators/guides/upgrading-your-node.md
+++ b/pages/operators/guides/upgrading-your-node.md
@@ -1,147 +1,212 @@
 # Upgrading your node
 
-Blockchain upgrades are a complex process that requires all network participants to agree on a specific time to execute a specific change in the protocol. Cosmos based networks, like the XRPL EVM Sidechain, solve this complexity with a set of fixed operations that need to happen when upgrading the chain:
+Upgrades are coordinated at a specific block height. Nodes running old binaries halt at that height and must be upgraded before they can continue.
 
-1. A governance proposal containing a chain upgrade transaction is created. This transaction contains specific details of the upgrade such as which block will the upgrade be executed, the version number and some metadata.
-2. Once the proposal is created it is voted as another regular governance proposal.
-3. If the proposal collects enough votes to be approved, the chain upgrade is planned at the block specified.
-4. When the block of the upgrade is minted, all the nodes, that are running the old version will halt, showing an error in the logs notifying the operator to upgrade it to the new binary.
-5. After more than 2/3 of the total validators upgrade their nodes, the chain starts creating new blocks. And the upgrade has finished successfully.
+For validators, the primary risk during upgrades is **double-signing**. This happens when more than one active validator signer uses the same validator key at the same time (or with inconsistent signer state), which can lead to slashing/jailing.
+
+This guide is a security-first runbook for all run stacks:
+
+- `systemctl`
+- `cosmovisor`
+- `docker`
+- raw binary upgrades
+- source-built upgrades
 
 {% admonition type="info" name="List of upgrades" %}
-In the [Networks](../resources/networks.md) page, you can find all the hard fork upgrades for each network
+Upgrade heights and target versions for Mainnet/Testnet/Devnet are listed in [Networks](../resources/networks.md).
 {% /admonition %}
 
-## Automated upgrades
+## Critical validator safety rules
 
-Manual actions required by node operators during the chain upgrades can be automated using Cosmovisor. This client automatically detects new binaries for newer versions available and downloads them. Once a new chain upgrade is triggered, the cosmovisor restarts the node with the new binary, reducing the downtime of your node.
+Follow these rules for every validator upgrade:
 
-{% admonition type="info" name="Important" %}
-The following instructions are adapted from the official Cosmovisor documentation. If you want more in-depth information or advanced usage, consult that resource.
+1. **One signer only**: keep a single active validator signer for `priv_validator_key.json`.
+2. **Stop before replace**: fully stop old process/container/service before changing binaries.
+3. **Preserve signer state**: never delete or roll back `priv_validator_state.json`.
+4. **Never clone signing state to a second active host**.
+5. **Verify single active instance** before restart.
+
+{% admonition type="warning" name="Double-sign risk" %}
+Do not start a second node (VM, container, backup host, or old binary) with the same validator key while your primary validator is still running. This is the most common path to double-signing.
 {% /admonition %}
 
-### Install Cosmovisor
+## Secure upgrade flow (mandatory order)
 
-You can download Cosmovisor from the [GitHub releases](https://github.com/cosmos/cosmos-sdk/releases/tag/cosmovisor%2Fv1.5.0).
+Use this exact sequence for validators, regardless of stack.
 
-To install the latest version of cosmovisor, run the following command:
+### 1) Confirm target upgrade
+
+- Read target height/version from [Networks](../resources/networks.md).
+- Download the target release artifact from [XRPL EVM node releases](https://github.com/xrplevm/node/releases).
+
+### 2) Pre-upgrade checks
+
+```bash
+exrpd status
+```
+
+Record current height and ensure your node is healthy before starting.
+
+### 3) Stop signer process completely
+
+Stop your runtime stack and confirm the process is gone.
+
+```bash
+pgrep -fa exrpd
+```
+
+Expected: no active validator signer `exrpd` process.
+
+### 4) Backup validator-critical files
+
+```bash
+mkdir -p ~/exrpd-upgrade-backup
+cp ~/.exrpd/config/priv_validator_key.json ~/exrpd-upgrade-backup/
+cp ~/.exrpd/data/priv_validator_state.json ~/exrpd-upgrade-backup/
+cp ~/.exrpd/config/node_key.json ~/exrpd-upgrade-backup/
+```
+
+Do not edit these files manually.
+
+### 5) Upgrade binary (raw or source)
+
+#### Raw binary upgrade
+
+```bash
+cd /tmp
+wget https://github.com/xrplevm/node/releases/download/<target-tag>/node_<target-version>_Linux_amd64.tar.gz
+tar -xzf node_<target-version>_Linux_amd64.tar.gz
+sudo mv bin/exrpd /usr/local/bin/exrpd
+sudo chmod +x /usr/local/bin/exrpd
+exrpd version
+```
+
+#### Upgrade from source
+
+```bash
+cd /tmp
+rm -rf node
+git clone https://github.com/xrplevm/node.git
+cd node
+git checkout <target-tag>
+make build
+sudo mv build/exrpd /usr/local/bin/exrpd
+sudo chmod +x /usr/local/bin/exrpd
+exrpd version
+```
+
+If you build from source, check required Go version first:
+
+```bash
+REQUIRED_GO=$(curl -fsSL https://raw.githubusercontent.com/xrplevm/node/main/go.mod | awk '/^go /{print $2; exit}')
+echo "Required Go: ${REQUIRED_GO}"
+go version
+```
+
+### 6) Start exactly one signer
+
+Start your runtime stack (only one instance) and follow logs.
+
+### 7) Post-upgrade validation
+
+```bash
+exrpd status
+curl -s localhost:26657/status | jq .result.sync_info
+```
+
+Confirm blocks are advancing and no upgrade halt error remains.
+
+## Stack-specific upgrade commands
+
+### `systemctl`
+
+```bash
+sudo systemctl stop exrpd
+pgrep -fa exrpd
+
+# replace /usr/local/bin/exrpd with target binary
+
+sudo systemctl start exrpd
+sudo journalctl -u exrpd -f
+```
+
+### `cosmovisor`
+
+Place the new binary in the upgrade folder matching the on-chain upgrade name:
+
+```bash
+mkdir -p ~/.exrpd/cosmovisor/upgrades/<upgrade-name>/bin
+cp /usr/local/bin/exrpd ~/.exrpd/cosmovisor/upgrades/<upgrade-name>/bin/exrpd
+chmod +x ~/.exrpd/cosmovisor/upgrades/<upgrade-name>/bin/exrpd
+```
+
+Then run:
+
+```bash
+sudo systemctl restart cosmovisor-exrpd
+sudo journalctl -u cosmovisor-exrpd -f
+```
+
+{% admonition type="warning" name="Cosmovisor path" %}
+Use `~/.exrpd/...` (not `~/.exprd/...`).
+{% /admonition %}
+
+### `docker`
+
+```bash
+docker pull peersyst/exrp:<target-tag>
+docker stop xrplevm-node
+docker rm xrplevm-node
+
+docker run -d \
+  --name xrplevm-node \
+  --restart unless-stopped \
+  -v /root/.exrpd:/root/.exrpd \
+  --entrypoint exrpd \
+  peersyst/exrp:<target-tag> \
+  start
+
+docker logs -f xrplevm-node
+```
+
+Do not keep an old validator container running in parallel.
+
+## Automated upgrades with Cosmovisor
+
+Cosmovisor can reduce manual intervention during upgrades. It can also increase operational risk if misconfigured, so validator operators should test in non-production first.
+
+Install:
 
 ```bash
 go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
-```
-
-To install a specific version, you can specify the version:
-
-```bash
-go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
-```
-
-Run cosmovisor version to check the cosmovisor version.
-
-```bash
 cosmovisor version
 ```
 
-### Directory Structure
-
-Cosmovisor requires a specific directory layout to manage your XRPL EVM sidechain binaries. The recommended structure is:
-
-```
-~/.exrpd/
-└── cosmovisor
-    ├── current -> genesis (symlink)
-    ├── genesis
-    │   └── bin
-    │       └── exrpd (the current binary)
-    └── upgrades
-        └── <upgrade-name>
-            └── bin
-                └── exrpd (new binary for the upgrade)
-```
-
-- `genesis/bin/exrpd` is your current XRPL EVM sidechain binary (the one you’re running).
-- `upgrades/<upgrade-name>/bin/exrpd` is where you place the upgraded binary once an on-chain upgrade is approved.
-
-### Configuration
-
-Cosmovisor uses environment variables to locate directories and manage behavior. The most important variables are:
-
-- `DAEMON_NAME`  
-  The name of the binary that Cosmovisor will run (e.g., `exrpd`).
-
-- `DAEMON_HOME`  
-  The path to the home directory for your chain (e.g., `~/.exrpd`).
-
-- `DAEMON_DATA_BACKUP_DIR`  
-  (Optional) A directory where Cosmovisor will store backups of data.
-
-- `UNSAFE_SKIP_BACKUP`  
-  Set to `true` or `false` depending on whether you want Cosmovisor to skip making data backups.
-
-- `DAEMON_RESTART_AFTER_UPGRADE`  
-  If `true`, Cosmovisor will automatically restart the node after the upgrade.
-
-- `DAEMON_ALLOW_DOWNLOAD_BINARIES`  
-  If `true`, Cosmovisor will attempt to download and install the binary itself based on the instructions in the info attribute in the data/upgrade-info.json file.
-
-A typical environment configuration might look like this:
+Recommended environment variables:
 
 ```bash
 export DAEMON_NAME=exrpd
 export DAEMON_HOME=$HOME/.exrpd
 export DAEMON_RESTART_AFTER_UPGRADE=true
 export UNSAFE_SKIP_BACKUP=false
-export DAEMON_ALLOW_DOWNLOAD_BINARIES=true
+export DAEMON_ALLOW_DOWNLOAD_BINARIES=false
 ```
 
-### Running the Node with Cosmovisor
-
-You can start the node with Cosmovisor directly from the command line:
-
-```bash
-cosmovisor start
-```
-
-This command uses `$DAEMON_NAME` (in this case, `exrpd`) and `$DAEMON_HOME` to locate your sidechain binary and configuration.
-
-### Performing Upgrades
-
-When an upgrade is triggered on-chain (via governance or other mechanisms), you need to:
-
-1. Download or build the **new** XRPL EVM sidechain binary.
-2. Create a subdirectory in `~/.exrpd/cosmovisor/upgrades/` corresponding to the upgrade name.
-3. Place the new binary inside a `bin/` folder within that subdirectory.
-4. Cosmovisor will detect the upgrade at the appointed block height and automatically switch to the new binary.
-
-#### Example Upgrade Directory
-
-If the upgrade name is `v7`, the new binary should be placed at:
-
-```
-~/.exprd/cosmovisor/upgrades/v7/bin/exrpd
-```
-
-Make sure to give execute permissions to the new binary:
-
-```bash
-chmod +x ~/.exrpd/cosmovisor/upgrades/v7/bin/exrpd
-```
-
-### Automated downloads
-
-Generally, cosmovisor requires that the system administrator place all relevant binaries on disk before the upgrade happens. However, for people who don't need such control and want an automated setup (maybe they are syncing a non-validating fullnode and want to do little maintenance), there is another option.
-
-{% admonition type="warning" name="Security note" %}
-We don't recommend using auto-download because it doesn't verify in advance if a binary is available. If there will be any issue with downloading a binary, the cosmovisor will stop and won't restart an App (which could lead to a chain halt).
+{% admonition type="warning" name="Auto-download caution" %}
+For validators, prefer `DAEMON_ALLOW_DOWNLOAD_BINARIES=false` and stage binaries manually. Auto-download introduces an external dependency at upgrade time.
 {% /admonition %}
 
-If `DAEMON_ALLOW_DOWNLOAD_BINARIES` is set to `true`, and no local binary can be found when an upgrade is triggered, cosmovisor will attempt to download and install the binary itself based on the instructions in the info attribute in the data/upgrade-info.json file. The files is constructed by the x/upgrade module and contains data from the upgrade Plan object.
+## Incident prevention checklist
+
+Before starting after upgrade, confirm:
+
+- old process is fully stopped
+- no second host/container is signing with same key
+- `priv_validator_state.json` is intact and not rolled back
+- target binary version is installed
+- logs show normal block progression
 
 ## Additional Resources
 
 - [Cosmovisor Docs (Cosmos SDK)](https://docs.cosmos.network/main/build/tooling/cosmovisor)
 - [XRPL EVM Sidechain Repository](https://github.com/xrplevm/node)
-
----
-
-**That’s it!** With Cosmovisor set up, your XRPL EVM sidechain node will automatically update to new binaries when an on-chain upgrade proposal is executed, reducing manual intervention and downtime.

--- a/pages/operators/guides/upgrading-your-node.md
+++ b/pages/operators/guides/upgrading-your-node.md
@@ -27,17 +27,23 @@ Follow these rules for every validator upgrade:
 5. **Verify single active instance** before restart.
 
 {% admonition type="warning" name="Double-sign risk" %}
-Do not start a second node (VM, container, backup host, or old binary) with the same validator key while your primary validator is still running. This is the most common path to double-signing.
+Do not start a second node (VM, container, backup host, or old binary) with the same validator key while your primary validator is still running. This is the most common path to double-signing and can tombstone your validator, meaning that validator key can never become an active validator again.
 {% /admonition %}
 
 ## Secure upgrade flow (mandatory order)
 
 Use this exact sequence for validators, regardless of stack.
 
+Use your actual node home path in commands below:
+
+- If you run as root defaults: `~/.exrpd`
+- If you followed hardened `systemd`/`cosmovisor` setup: `/var/lib/exrpd/.exrpd`
+
 ### 1) Confirm target upgrade
 
 - Read target height/version from [Networks](../resources/networks.md).
 - Download the target release artifact from [XRPL EVM node releases](https://github.com/xrplevm/node/releases).
+- Use the **on-chain upgrade name** from `upgrade-info.json` for Cosmovisor folder naming. Do not assume upgrade proposal name equals release tag (for example, proposal name `v10.0.0` may require binary `v10.0.1` or `v10.0.2`).
 
 ### 2) Pre-upgrade checks
 
@@ -60,10 +66,11 @@ Expected: no active validator signer `exrpd` process.
 ### 4) Backup validator-critical files
 
 ```bash
+NODE_HOME=${NODE_HOME:-~/.exrpd}
 mkdir -p ~/exrpd-upgrade-backup
-cp ~/.exrpd/config/priv_validator_key.json ~/exrpd-upgrade-backup/
-cp ~/.exrpd/data/priv_validator_state.json ~/exrpd-upgrade-backup/
-cp ~/.exrpd/config/node_key.json ~/exrpd-upgrade-backup/
+cp "$NODE_HOME"/config/priv_validator_key.json ~/exrpd-upgrade-backup/
+cp "$NODE_HOME"/data/priv_validator_state.json ~/exrpd-upgrade-backup/
+cp "$NODE_HOME"/config/node_key.json ~/exrpd-upgrade-backup/
 ```
 
 Do not edit these files manually.
@@ -74,8 +81,9 @@ Do not edit these files manually.
 
 ```bash
 cd /tmp
-wget https://github.com/xrplevm/node/releases/download/<target-tag>/node_<target-version>_Linux_amd64.tar.gz
-tar -xzf node_<target-version>_Linux_amd64.tar.gz
+TARGET_TAG=<target-tag>
+wget "https://github.com/xrplevm/node/releases/download/${TARGET_TAG}/node_${TARGET_TAG#v}_Linux_amd64.tar.gz"
+tar -xzf "node_${TARGET_TAG#v}_Linux_amd64.tar.gz"
 sudo mv bin/exrpd /usr/local/bin/exrpd
 sudo chmod +x /usr/local/bin/exrpd
 exrpd version
@@ -102,6 +110,29 @@ REQUIRED_GO=$(curl -fsSL https://raw.githubusercontent.com/xrplevm/node/main/go.
 echo "Required Go: ${REQUIRED_GO}"
 go version
 ```
+
+### 5.1) Apply mandatory EVM chain-id config (v10+)
+
+After installing the target binary and **before starting the node**, ensure `evm-chain-id` is present under `[evm]` in `app.toml`:
+
+- Mainnet (`xrplevm_1440000-1`): `evm-chain-id = "1440000"`
+- Testnet (`xrplevm_1449000-1`): `evm-chain-id = "1449000"`
+
+File location depends on your home path:
+
+- `~/.exrpd/config/app.toml`
+- or `/var/lib/exrpd/.exrpd/config/app.toml`
+
+Example check:
+
+```bash
+NODE_HOME=${NODE_HOME:-~/.exrpd}
+awk '/^\[evm\]/{f=1;next} /^\[/{f=0} f && /^evm-chain-id/{print;found=1} END{if(!found) print "MISSING"}' "$NODE_HOME"/config/app.toml
+```
+
+{% admonition type="warning" name="Consensus safety" %}
+If `evm-chain-id` is missing or wrong for your network, your node can fail to participate correctly in consensus after upgrade height.
+{% /admonition %}
 
 ### 6) Start exactly one signer
 
@@ -135,10 +166,21 @@ sudo journalctl -u exrpd -f
 Place the new binary in the upgrade folder matching the on-chain upgrade name:
 
 ```bash
-mkdir -p ~/.exrpd/cosmovisor/upgrades/<upgrade-name>/bin
-cp /usr/local/bin/exrpd ~/.exrpd/cosmovisor/upgrades/<upgrade-name>/bin/exrpd
-chmod +x ~/.exrpd/cosmovisor/upgrades/<upgrade-name>/bin/exrpd
+DAEMON_HOME=${DAEMON_HOME:-~/.exrpd}
+mkdir -p "$DAEMON_HOME"/cosmovisor/upgrades/<upgrade-name>/bin
+cp /usr/local/bin/exrpd "$DAEMON_HOME"/cosmovisor/upgrades/<upgrade-name>/bin/exrpd
+chmod +x "$DAEMON_HOME"/cosmovisor/upgrades/<upgrade-name>/bin/exrpd
 ```
+
+If `upgrade-info.json` is present, you can derive the folder name directly:
+
+```bash
+DAEMON_HOME=${DAEMON_HOME:-~/.exrpd}
+UPGRADE_NAME=$(jq -r '.name // empty' "$DAEMON_HOME"/data/upgrade-info.json 2>/dev/null || true)
+echo "$UPGRADE_NAME"
+```
+
+`UPGRADE_NAME` is the folder to use under `cosmovisor/upgrades/`, even when the required release binary version differs from that name.
 
 Then run:
 
@@ -171,6 +213,69 @@ docker logs -f xrplevm-node
 
 Do not keep an old validator container running in parallel.
 
+## Hotfix recovery runbook (only for impacted existing nodes)
+
+Use this section only when governance/core team announces an incident hotfix and your node/validator was already running and impacted.
+
+If you are a fresh node setup, skip this section and follow the normal install flow for your network's current version.
+
+1. Stop all signer instances that could use the same validator key, then verify no signer is running:
+
+```bash
+sudo systemctl stop exrpd 2>/dev/null || true
+sudo systemctl stop cosmovisor-exrpd 2>/dev/null || true
+docker stop xrplevm-node 2>/dev/null || true
+pgrep -fa exrpd
+```
+
+Expected: no active validator signer process.
+
+2. Install the announced hotfix binary (do not start yet).
+3. Backup signer state:
+
+```bash
+cp ~/.exrpd/data/priv_validator_state.json ~/.exrpd/priv_validator_state.json
+```
+
+4. Restore state:
+  - Recommended: restore from a compatible snapshot provider (for example PolkaChu, Cumulo, or XRPL EVM snapshot S3).
+  - Alternative (resource-heavy): `exrpd rollback`
+5. Apply required config changes announced with the hotfix.
+
+If governance requires an EVM chain-id update, set it in `app.toml` under `[evm]`:
+
+```toml
+[evm]
+evm-chain-id = "<network-evm-chain-id>"
+```
+
+6. Restore signer state file and permissions:
+
+```bash
+cp ~/.exrpd/priv_validator_state.json ~/.exrpd/data/priv_validator_state.json
+chmod 600 ~/.exrpd/data/priv_validator_state.json
+```
+
+7. Before start, confirm only one host/container will be allowed to sign with this validator key.
+
+8. Start exactly one runtime stack:
+
+```bash
+exrpd start
+```
+
+{% admonition type="warning" name="Critical double-sign protection" %}
+Never run two active instances with the same `priv_validator_key.json` at the same time (primary + backup, old + new binary, systemd + docker, etc.). During hotfixes, this is the highest-risk mistake and can lead to slashing/jailing and tombstoning (permanent validator removal for that key).
+{% /admonition %}
+
+{% admonition type="info" name="Current known example" %}
+During the Testnet v10 incident, affected nodes moved from `v10.0.0` to `v10.0.1` and required `evm-chain-id = "1449000"`.
+{% /admonition %}
+
+{% admonition type="info" name="Snapshot restore during incident" %}
+If restoring from a pre-upgrade snapshot with Cosmovisor, stage the required binary in the upgrade folder from `upgrade-info.json` before service start.
+{% /admonition %}
+
 ## Automated upgrades with Cosmovisor
 
 Cosmovisor can reduce manual intervention during upgrades. It can also increase operational risk if misconfigured, so validator operators should test in non-production first.
@@ -178,8 +283,10 @@ Cosmovisor can reduce manual intervention during upgrades. It can also increase 
 Install:
 
 ```bash
-go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
-cosmovisor version
+sudo apt-get update
+sudo apt-get install -y golang-go
+sudo env GOBIN=/usr/local/bin go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
+/usr/local/bin/cosmovisor --help >/dev/null
 ```
 
 Recommended environment variables:

--- a/pages/operators/resources/configuration-reference.md
+++ b/pages/operators/resources/configuration-reference.md
@@ -15,7 +15,7 @@ This page provides a reference for configuring the XRPL EVM sidechain nodes usin
 
 # The version of the CometBFT binary that created or
 # last modified the config file. Do not modify this.
-version = "0.38.15"
+version = "0.38.19"
 
 #######################################################################
 ###                   Main Base Config Options                      ###
@@ -395,6 +395,9 @@ chunk_request_timeout = "10s"
 # The number of concurrent chunk fetchers to run (default: 1).
 chunk_fetchers = "4"
 
+# Maximum number of chunks allowed in a snapshot (default: 100000).
+max_snapshot_chunks = 100000
+
 #######################################################
 ###       Block Sync Configuration Options          ###
 #######################################################
@@ -507,6 +510,17 @@ namespace = "cometbft"
 
 ## `app.toml`
 
+{% admonition type="warning" name="Default template vs network-required values" %}
+The values shown below are reference defaults from a generated `app.toml` template. They are not guaranteed to match your target network.
+
+For production use, set `[evm].evm-chain-id` to the correct network value before starting:
+
+- Mainnet: `1440000`
+- Testnet: `1449000`
+
+See [Networks](./networks.md) for current network targets and versions.
+{% /admonition %}
+
 ```toml
 # This is a TOML config file.
 # For more information, see https://github.com/toml-lang/toml
@@ -576,7 +590,7 @@ index-events = []
 # IavlCacheSize set the size of the iavl tree cache (in number of nodes).
 iavl-cache-size = 781250
 
-# IAVLDisableFastNode enables or disables the fast node feature of IAVL.
+# IAVLDisableFastNode enables or disables the fast node feature of IAVL. 
 # Default is false.
 iavl-disable-fastnode = false
 
@@ -667,7 +681,7 @@ enabled-unsafe-cors = false
 [grpc]
 
 # Enable defines if the gRPC server should be enabled.
-enable = false
+enable = true
 
 # Address defines the gRPC server address to bind to.
 address = "localhost:9090"
@@ -680,6 +694,13 @@ max-recv-msg-size = "10485760"
 # The default value is math.MaxInt32.
 max-send-msg-size = "2147483647"
 
+# Historical gRPC addresses with block ranges for historical query routing.
+# This should be a JSON string mapping gRPC addresses to block ranges.
+# Format: '{"address1": [start_block, end_block], "address2": [start_block, end_block]}'
+# Example: '{"0.0.0.0:26113": [0, 1000], "0.0.0.0:26114": [1001, 2000]}'
+# Leave empty to disable historical gRPC routing.
+historical-grpc-address-block-range = "{}"
+
 ###############################################################################
 ###                        gRPC Web Configuration                           ###
 ###############################################################################
@@ -689,7 +710,7 @@ max-send-msg-size = "2147483647"
 # GRPCWebEnable defines if the gRPC-web should be enabled.
 # NOTE: gRPC must also be enabled, otherwise, this configuration is a no-op.
 # NOTE: gRPC-Web uses the same address as the API server.
-enable = false
+enable = true
 
 ###############################################################################
 ###                        State Sync Configuration                         ###
@@ -759,6 +780,42 @@ tracer = ""
 # MaxTxGasWanted defines the gas wanted for each eth tx returned in ante handler in check tx mode.
 max-tx-gas-wanted = 0
 
+# EnablePreimageRecording enables tracking of SHA3 preimages in the VM
+cache-preimage = false
+
+# EVMChainID is the EIP-155 compatible replay protection chain ID. This is separate from the Cosmos chain ID.
+evm-chain-id = 9999
+
+# MinTip defines the minimum priority fee for the mempool.
+min-tip = 0
+
+# GethMetricsAddress defines the addr to bind the geth metrics server to. Default 127.0.0.1:8100.
+geth-metrics-address = "127.0.0.1:8100"
+
+# Mempool configuration for EVM transactions
+[evm.mempool]
+
+# PriceLimit is the minimum gas price to enforce for acceptance into the pool (in wei)
+price-limit = 1
+
+# PriceBump is the minimum price bump percentage to replace an already existing transaction (nonce)
+price-bump = 10
+
+# AccountSlots is the number of executable transaction slots guaranteed per account
+account-slots = 16
+
+# GlobalSlots is the maximum number of executable transaction slots for all accounts
+global-slots = 5120
+
+# AccountQueue is the maximum number of non-executable transaction slots permitted per account
+account-queue = 64
+
+# GlobalQueue is the maximum number of non-executable transaction slots for all accounts
+global-queue = 1024
+
+# Lifetime is the maximum amount of time non-executable transaction are queued
+lifetime = "3h0m0s"
+
 ###############################################################################
 ###                           JSON RPC Configuration                        ###
 ###############################################################################
@@ -773,6 +830,10 @@ address = "127.0.0.1:8545"
 
 # Address defines the EVM WebSocket server address to bind to.
 ws-address = "127.0.0.1:8546"
+
+# WSOrigins defines the allowed origins for WebSocket connections.
+# Example: ["localhost", "127.0.0.1", "myapp.example.com"]
+ws-origins = ["127.0.0.1", "localhost"]
 
 # API defines a list of JSON-RPC namespaces that should be enabled
 # Example: "eth,txpool,personal,net,debug,web3"
@@ -823,8 +884,14 @@ enable-indexer = false
 # Prometheus metrics path: /debug/metrics/prometheus
 metrics-address = "127.0.0.1:6065"
 
-# Upgrade height for fix of revert gas refund logic when transaction reverted.
-fix-revert-gas-refund-height = 0
+# Maximum number of requests in a batch.
+batch-request-limit = 1000
+
+# Maximum number of bytes returned from a batched call.
+batch-response-max-size = 25000000
+
+# Enabled profiling in the debug namespace
+enable-profiling = false
 
 ###############################################################################
 ###                             TLS Configuration                           ###
@@ -837,88 +904,6 @@ certificate-path = ""
 
 # Key path defines the key.pem file path for the TLS configuration.
 key-path = ""
-
-###############################################################################
-###                           Rosetta Configuration                         ###
-###############################################################################
-
-[rosetta]
-
-# Enable defines if the Rosetta API server should be enabled.
-enable = false
-
-# Address defines the Rosetta API server to listen on.
-address = ":8080"
-
-# Network defines the name of the blockchain that will be returned by Rosetta.
-blockchain = "exrp"
-
-# Network defines the name of the network that will be returned by Rosetta.
-network = "exrp"
-
-# TendermintRPC defines the endpoint to connect to CometBFT RPC,
-# specifying 'tcp://' before is not required, usually it's at port 26657
-tendermint-rpc = "localhost:26657"
-
-# GRPCEndpoint defines the cosmos application gRPC endpoint
-# usually it is located at 9090 port
-grpc-endpoint = "localhost:9090"
-
-# Retries defines the number of retries when connecting to the node before failing.
-retries = 5
-
-# Offline defines if Rosetta server should run in offline mode.
-offline = false
-
-# EnableFeeSuggestion indicates to use fee suggestion when 'construction/metadata' is called without gas limit and price.
-enable-fee-suggestion = false
-
-# GasToSuggest defines gas limit when calculating the fee
-gas-to-suggest = 300000
-
-# DenomToSuggest defines the defult denom for fee suggestion.
-# Price must be in minimum-gas-prices.
-denom-to-suggest = "axrp"
-
-# GasPrices defines the gas prices for fee suggestion
-gas-prices = "4000000.000000000000000000axrp"
-
-###############################################################################
-###                         VersionDB Configuration                         ###
-###############################################################################
-
-[versiondb]
-
-# Enable defines if the versiondb should be enabled.
-enable = false
-
-###############################################################################
-###                             MemIAVL Configuration                       ###
-###############################################################################
-
-[memiavl]
-
-# Enable defines if the memiavl should be enabled.
-enable = false
-
-# ZeroCopy defines if the memiavl should return slices pointing to mmap-ed buffers directly (zero-copy),
-# the zero-copied slices must not be retained beyond current block's execution.
-# the sdk address cache will be disabled if zero-copy is enabled.
-zero-copy = false
-
-# AsyncCommitBuffer defines the size of asynchronous commit queue, this greatly improve block catching-up
-# performance, -1 means synchronous commit.
-async-commit-buffer = 0
-
-# SnapshotKeepRecent defines what many old snapshots (excluding the latest one) to keep after new snapshots are
-# taken, defaults to 1 to make sure ibc relayers work.
-snapshot-keep-recent = 1
-
-# SnapshotInterval defines the block interval the memiavl snapshot is taken, default to 1000.
-snapshot-interval = 1000
-
-# CacheSize defines the size of the cache for each memiavl store, default to 1000.
-cache-size = 1000
 ```
 
 ## `client.toml`
@@ -933,12 +918,19 @@ cache-size = 1000
 
 # The network chain ID
 chain-id = ""
+
 # The keyring's backend, where the keys are stored (os|file|kwallet|pass|test|memory)
 keyring-backend = "os"
+
+# Default key name, if set, defines the default key to use for signing transaction when the --from flag is not specified
+keyring-default-keyname = ""
+
 # CLI output format (text|json)
 output = "text"
+
 # <host>:<port> to CometBFT RPC interface for this chain
 node = "tcp://localhost:26657"
+
 # Transaction broadcasting mode (sync|async)
 broadcast-mode = "sync"
 ```

--- a/pages/operators/resources/networks.md
+++ b/pages/operators/resources/networks.md
@@ -4,7 +4,7 @@ The XRPL EVM ecosystem consists of multiple networks, each serving different sta
 
 | Name    | Chain ID         | Current Version | Genesis                                                                                            | Peers                                                                                         |
 | ------- | ---------------- | --------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| Mainnet | `xrplevm_1440000-1` | v8.0.2          | [Genesis](https://raw.githubusercontent.com/xrplevm/networks/refs/heads/main/mainnet/genesis.json) | [Peers](https://raw.githubusercontent.com/xrplevm/networks/main/mainnet/peers.txt)            |
+| Mainnet | `xrplevm_1440000-1` | v10.0.2          | [Genesis](https://raw.githubusercontent.com/xrplevm/networks/refs/heads/main/mainnet/genesis.json) | [Peers](https://raw.githubusercontent.com/xrplevm/networks/main/mainnet/peers.txt)            |
 | Testnet | `xrplevm_1449000-1` | v10.0.1          | [Genesis](https://raw.githubusercontent.com/xrplevm/networks/refs/heads/main/testnet/genesis.json) | [Peers](https://raw.githubusercontent.com/xrplevm/networks/main/testnet/peers.txt)            |
 | Devnet | `xrplevm_1449900-1` | v9.0.3          | [Genesis](https://raw.githubusercontent.com/xrplevm/networks/refs/heads/main/devnet/genesis.json) | [Peers](https://raw.githubusercontent.com/xrplevm/networks/main/devnet/peers.txt)            |
 
@@ -19,9 +19,10 @@ Below is a table indicating all the hard fork upgrades for each network:
 
 | Upgrade Name | Block Height | Upgrade Date | Binary Version                                                | Docker image                                                                                                                                              |
 | ------------ | ------------ | ------------ | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Genesis      | 0            | 2025-04-25   | [v7.0.0](https://github.com/xrplevm/node/releases/tag/v7.0.0) | [peersyst/exrp:v7.0.0](https://hub.docker.com/layers/peersyst/exrp/v7.0.0/images/sha256-dd77f81a2f8e349349fcd1266c465c77e580681764f0abbdd052bd4f4360c24e) |
-| v8           | 497000       | 2025-05-28   | [v8.0.2](https://github.com/xrplevm/node/releases/tag/v8.0.2) | [peersyst/exrp:v8.0.2](https://hub.docker.com/layers/peersyst/exrp/v8.0.2/images/sha256-2fba5b2bef8a203b3226ff88d5c5018a67370d2e4a6838d25809424223f7f3a8) |
-| v9           | 4688681       | 2026-02-26   | [v9.0.3](https://github.com/xrplevm/node/releases/tag/v9.0.3) | [peersyst/exrp:v9.0.3](https://hub.docker.com/layers/peersyst/exrp/v9.0.3/images/sha256-2fba5b2bef8a203b3226ff88d5c5018a67370d2e4a6838d25809424223f7f3a8) |
+| Genesis      | 0            | 2025-04-25   | [v7.0.0](https://github.com/xrplevm/node/releases/tag/v7.0.0) | [peersyst/exrp:v7.0.0](https://hub.docker.com/layers/peersyst/exrp/v7.0.0/images/sha256:dd77f81a2f8e349349fcd1266c465c77e580681764f0abbdd052bd4f4360c24e) |
+| v8           | 497000       | 2025-05-28   | [v8.0.2](https://github.com/xrplevm/node/releases/tag/v8.0.2) | [peersyst/exrp:v8.0.2](https://hub.docker.com/layers/peersyst/exrp/v8.0.2/images/sha256:282ea8aba12ad507ff9df6b65eb83d7696b71dda0426bcbdfb357dcd2cd7bbc3) |
+| v9           | 4688681       | 2026-02-26   | [v9.0.3](https://github.com/xrplevm/node/releases/tag/v9.0.3) | [peersyst/exrp:v9.0.3](https://hub.docker.com/layers/peersyst/exrp/v9.0.3/images/sha256:29825f07db1011974d25f2531eb4981258f639de7b5ad73f383eab64a65f9847) |
+| v10           | 4749000       | 2026-03-02   | [v10.0.2](https://github.com/xrplevm/node/releases/tag/v10.0.2) | [peersyst/exrp:v10.0.2](https://hub.docker.com/layers/peersyst/exrp/v10.0.2/images/sha256:19ffb90a84639d8433b0896fedb106acec315e9b4da197d08204ffe67c5a42fb) |
 
 
 {% /tab %}
@@ -31,10 +32,10 @@ Below is a table indicating all the hard fork upgrades for each network:
 | Upgrade Name | Block Height | Upgrade Date | Binary Version                                                | Docker image                                                                                                                                              |
 | ------------ | ------------ | ------------ | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Genesis      | 0            | 2025-02-17   | [v6.0.0](https://github.com/xrplevm/node/releases/tag/v6.0.0) | [peersyst/exrp:v6.0.0](https://hub.docker.com/layers/peersyst/exrp/v6.0.0/images/sha256-9d8c9f96e27c648216fddbc4bb67c10529aa5ea03d303cf56060e453c02a4ca9) |
-| v7           | 547100       | 2025-03-25   | [v7.0.0](https://github.com/xrplevm/node/releases/tag/v7.0.0) | [peersyst/exrp:v7.0.0](https://hub.docker.com/layers/peersyst/exrp/v7.0.0/images/sha256-9d8c9f96e27c648216fddbc4bb67c10529aa5ea03d303cf56060e453c02a4ca9) |
+| v7           | 547100       | 2025-03-25   | [v7.0.0](https://github.com/xrplevm/node/releases/tag/v7.0.0) | [peersyst/exrp:v7.0.0](https://hub.docker.com/layers/peersyst/exrp/v7.0.0/images/sha256:dd77f81a2f8e349349fcd1266c465c77e580681764f0abbdd052bd4f4360c24e) |
 | v8           | 1485600       | 2025-05-26   | [v8.0.0](https://github.com/xrplevm/node/releases/tag/v8.0.0) | [peersyst/exrp:v8.0.0](https://hub.docker.com/layers/peersyst/exrp/v8.0.0/images/sha256-2fba5b2bef8a203b3226ff88d5c5018a67370d2e4a6838d25809424223f7f3a8) |
-| v9           | 3827000       | 2025-10-29   | [v9.0.0](https://github.com/xrplevm/node/releases/tag/v9.0.0) | [peersyst/exrp:v9.0.0](https://hub.docker.com/layers/peersyst/exrp/v9.0.0/images/sha256:9444e5cee345716ffa783fea084e2d9b6cec43a6800cbcf7507e566b7f5e8d86) |
-| v10           | 5601606       | 2026-02-23   | [v10.0.1](https://github.com/xrplevm/node/releases/tag/v10.0.1) | [peersyst/exrp:v10.0.1](https://hub.docker.com/layers/peersyst/exrp/v10.0.1/images/sha256:9444e5cee345716ffa783fea084e2d9b6cec43a6800cbcf7507e566b7f5e8d86) |
+| v9           | 3827000       | 2025-10-29   | [v9.0.3](https://github.com/xrplevm/node/releases/tag/v9.0.3) | [peersyst/exrp:v9.0.3](https://hub.docker.com/layers/peersyst/exrp/v9.0.3/images/sha256:29825f07db1011974d25f2531eb4981258f639de7b5ad73f383eab64a65f9847) |
+| v10           | 5601606       | 2026-02-23   | [v10.0.1](https://github.com/xrplevm/node/releases/tag/v10.0.1) | [peersyst/exrp:v10.0.1](https://hub.docker.com/layers/peersyst/exrp/v10.0.1/images/sha256:4c3bfb17f3ba39680b3770f5e5ae3247643bdae6ed8f90da5c6293f11933cc01) |
 
 {% /tab %}
 
@@ -42,7 +43,7 @@ Below is a table indicating all the hard fork upgrades for each network:
 
 | Upgrade Name | Block Height | Upgrade Date | Binary Version                                                | Docker image                                                                                                                                              |
 | ------------ | ------------ | ------------ | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Genesis      | 0            | 2026-01-27   | [v9.0.3](https://github.com/xrplevm/node/releases/tag/v9.0.3) | [peersyst/exrp:v9.0.3](https://hub.docker.com/layers/peersyst/exrp/v9.0.3/images/sha256-9d8c9f96e27c648216fddbc4bb67c10529aa5ea03d303cf56060e453c02a4ca9) |
+| Genesis      | 0            | 2026-01-27   | [v9.0.3](https://github.com/xrplevm/node/releases/tag/v9.0.3) | [peersyst/exrp:v9.0.3](https://hub.docker.com/layers/peersyst/exrp/v9.0.3/images/sha256:29825f07db1011974d25f2531eb4981258f639de7b5ad73f383eab64a65f9847) |
 
 {% /tab %}
 {% /tabs %}

--- a/pages/operators/resources/snapshots.md
+++ b/pages/operators/resources/snapshots.md
@@ -26,3 +26,50 @@ Snapshots provide a quick way to bootstrap your node’s state by downloading a 
 {% /tabs %}
 
 **Note:** Always verify the authenticity and integrity of snapshots before using them. Keep in mind that third-party providers may have different update schedules, data policies, and retention periods. Refer to the provider’s documentation for instructions on how to use these snapshots and any associated terms of service.
+
+## Restore examples
+
+Use the command set that matches the provider archive format.
+
+### Peersyst (`.tar.lz4`)
+
+```bash
+cd ~/.exrpd
+wget -O snapshot.tar.lz4 <snapshot_url>
+tar -xI lz4 -f snapshot.tar.lz4
+```
+
+### Cumulo (`.tar.zst`)
+
+```bash
+sudo apt update && sudo apt install -y aria2 zstd curl
+
+SERVICE=exrpd.service
+STATE=~/.exrpd/data/priv_validator_state.json
+BACKUP=/tmp/priv_validator_state.json
+
+sudo systemctl stop $SERVICE
+
+if [ -f "$STATE" ]; then
+	cp "$STATE" "$BACKUP"
+fi
+
+rm -rf ~/.exrpd/data && mkdir -p ~/.exrpd/data
+cd ~/.exrpd
+aria2c -x 16 -s 16 -k 1M --file-allocation=none -o snapshot.tar.zst "https://xrpl.cumulo.com.es/snapshots/latest_xrpl_snapshot.tar.zst"
+zstd -t snapshot.tar.zst
+tar --use-compress-program=zstd -xf snapshot.tar.zst -C ~/.exrpd/data
+rm -f snapshot.tar.zst
+
+if [ -f "$BACKUP" ]; then
+	mv "$BACKUP" "$STATE"
+fi
+
+sudo systemctl start $SERVICE
+```
+
+{% admonition type="warning" name="Validator signer safety" %}
+Restore `priv_validator_state.json` after extraction when replacing data, and keep only one active validator signer for the same `priv_validator_key.json`.
+{% /admonition %}
+
+If integrity check fails (`zstd -t` or tar extraction errors such as `Unexpected EOF`), delete the archive and download it again before extracting.

--- a/pages/operators/sidebars.yaml
+++ b/pages/operators/sidebars.yaml
@@ -3,6 +3,7 @@
   items:
     - page: ./getting-started/system-requirements.md
     - page: ./getting-started/installing-the-node.md
+    - page: ./getting-started/sync-from-genesis.md
     - page: ./getting-started/join-the-xrplevm.md
 - group: Guides
   items:

--- a/pages/operators/validators/maintaining-the-validator.md
+++ b/pages/operators/validators/maintaining-the-validator.md
@@ -1,6 +1,10 @@
 # Maintaining your validator
 
-The following page explains how to maintain your validator. This includes some useful commands that validators can use for editing the validator, ensure it is running properly and doing maintenance tasks.key
+The following page explains how to maintain your validator. This includes useful commands for editing validator metadata, confirming validator health, and performing maintenance safely.
+
+{% admonition type="warning" name="Double-sign prevention" %}
+Keep a **single active validator signer** only. Never run two active instances with the same `~/.exrpd/config/priv_validator_key.json`, and never roll back `~/.exrpd/data/priv_validator_state.json`.
+{% /admonition %}
 
 ## Edit Validator Description
 
@@ -62,10 +66,24 @@ Your validator is active if the following command returns anything:
 exrpd query tendermint-validator-set | grep "$(exrpd tendermint show-address)"
 ```
 
-You should now see your validator in one of the Exrp explorers. You are looking for the `bech32` encoded `address` in the `~/.exprd/config/priv_validator.json` file. <!-- SPELLING_IGNORE: exrp -->
+You should now see your validator in one of the Exrp explorers. You are looking for the `bech32` encoded `address` in the `~/.exrpd/config/priv_validator_key.json` file. <!-- SPELLING_IGNORE: exrp -->
 
 **Note** To be in the validator set, you must have more total voting power than the 100th validator.
 
 ## Halting Your Validator
 
 When attempting to perform routine maintenance or planning for an upcoming coordinated upgrade, it can be useful to have your validator systematically and gracefully halt. Set the `halt-height` to the height at which you want your node to shut down, or pass the `--halt-height` flag to `exrpd`. The node shuts down with a 0 exit code at that given height after committing the block.
+
+## Secure maintenance checklist (validators)
+
+Use this checklist before restarting a validator:
+
+1. Stop the node process (`systemctl`, `cosmovisor`, or `docker`) and confirm no active validator signer `exrpd` process remains.
+2. Confirm no second host/container is running as an active validator signer with the same validator key.
+3. Back up signer files:
+  - `~/.exrpd/config/priv_validator_key.json`
+  - `~/.exrpd/data/priv_validator_state.json`
+4. Perform maintenance or upgrade.
+5. Start exactly one signer instance and monitor logs.
+
+For full upgrade runbook steps, see [Upgrading your node](../guides/upgrading-your-node.md).

--- a/pages/operators/validators/managing-keys.md
+++ b/pages/operators/validators/managing-keys.md
@@ -9,7 +9,7 @@ Validators in the XRPL EVM sidechain rely on two distinct types of keys, each se
 ### Node Key
 
 - **Purpose**: Used for consensus and block signing.
-- **Location**: Stored in `config/priv_val_key.json`.
+- **Location**: Stored in `config/priv_validator_key.json`.
 - **Importance**: The node key is critical for validator operations. If compromised, it could allow malicious actors to manipulate block signing, impacting the chain's integrity.
 
 ### Operator Key

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -27,9 +27,6 @@ navbar:
       page: pages/bridge/index.md
       linkedSidebars:
         - pages/bridge/sidebars.yaml
-    - label: Ask GPT
-      href: https://chatgpt.com/g/g-6785069c998c819194463b60be890917-xrpl-evm-docs
-      external: true
     # - label: Core
     #   page: pages/core/index.md
     #   linkedSidebars:


### PR DESCRIPTION
This PR refreshes and hardens XRPL EVM operator documentation for Cosmos EVM 0.6.0, with a snapshot-first install flow and clearer upgrade/sync guidance.

Key changes:

* Added quick-reference maps and safety warnings (single signer / `priv_validator_*` handling) across install, sync, upgrades, snapshots, and validator maintenance.
* Reworked **Installing the node** into a clearer, operator-first flow (raw binaries + source + systemd/cosmovisor/docker) and documented mandatory `evm-chain-id` (v10+).
* Expanded **Join the XRPL EVM** to include **Devnet** instructions and cleaned up seed/peer snippets.
* Added a dedicated **Sync from Genesis** guide with upgrade-path tables per network.
* Updated CLI guide examples to use `<chain-id>` placeholders and improved config command notes.
* Updated config reference notes (CometBFT/app.toml defaults vs network-required values; gRPC/ws settings).
* Updated Networks/Snapshots pages with restore examples and latest upgrade/version references.
* Removed “Ask GPT” link from navbar (redocly).
